### PR TITLE
fix: Linux/Windows agent user management - remove unnecessary service account requirement

### DIFF
--- a/agent/functions/userAdmin/userAdmin.go
+++ b/agent/functions/userAdmin/userAdmin.go
@@ -40,17 +40,9 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 	response.RequestID = request.RequestID
 	response.Success = false
 
-	// Obtain admin password from config
-	adminUser, adminPassword, err := h.config.GetServiceCredentials()
-	if err != nil {
-		response.Response = fmt.Sprintf("unable to obtian service account credentials: %s", err.Error())
-		return response, errors.New(response.Response)
-	}
-
-	userInfo := osActions.UserInfo{
-		AdminUser:     adminUser,
-		AdminPassword: adminPassword,
-	}
+	// Note: setAdmin does not require service account credentials on any platform
+	// as it runs with elevated privileges
+	userInfo := osActions.UserInfo{}
 
 	username, ok := request.Parameters["user"]
 	if !ok || username == "" {

--- a/agent/functions/userDelete/userDelete.go
+++ b/agent/functions/userDelete/userDelete.go
@@ -8,6 +8,7 @@ package userDelete
 import (
 	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/global"
@@ -45,11 +46,16 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 		return response, errors.New(response.Response)
 	}
 
-	// Obtain admin password from config
-	adminUser, adminPassword, err := h.config.GetServiceCredentials()
-	if err != nil {
-		response.Response = fmt.Sprintf("unable to obtian service account credentials: %s", err.Error())
-		return response, errors.New(response.Response)
+	// Service account credentials are only required on macOS for FileVault operations
+	// On Linux and Windows, the agent runs with elevated privileges and doesn't need them
+	var adminUser, adminPassword string
+	var err error
+	if runtime.GOOS == "darwin" {
+		adminUser, adminPassword, err = h.config.GetServiceCredentials()
+		if err != nil {
+			response.Response = fmt.Sprintf("unable to obtain service account credentials: %s", err.Error())
+			return response, errors.New(response.Response)
+		}
 	}
 
 	userInfo := osActions.UserInfo{

--- a/agent/functions/userLock/userLock.go
+++ b/agent/functions/userLock/userLock.go
@@ -8,6 +8,7 @@ package userLock
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/UnifyEM/UnifyEM/agent/communications"
@@ -60,17 +61,10 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 		fields.NewField("user", username),
 	)
 
-	// Obtain admin password from config
-	adminUser, adminPassword, err := h.config.GetServiceCredentials()
-	if err != nil {
-		response.Response = fmt.Sprintf("unable to obtian service account credentials: %s", err.Error())
-		return response, errors.New(response.Response)
-	}
-
+	// Note: lockUser does not require service account credentials on any platform
+	// as it runs with elevated privileges
 	userInfo := osActions.UserInfo{
-		Username:      username,
-		AdminUser:     adminUser,
-		AdminPassword: adminPassword,
+		Username: username,
 	}
 
 	a := osActions.New(h.logger)

--- a/agent/functions/userUnlock/userUnlock.go
+++ b/agent/functions/userUnlock/userUnlock.go
@@ -8,6 +8,7 @@ package userUnlock
 import (
 	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/global"
@@ -51,11 +52,16 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 		return response, errors.New(response.Response)
 	}
 
-	// Obtain admin password from config
-	adminUser, adminPassword, err := h.config.GetServiceCredentials()
-	if err != nil {
-		response.Response = fmt.Sprintf("unable to obtian service account credentials: %s", err.Error())
-		return response, errors.New(response.Response)
+	// Service account credentials are only required on macOS for FileVault operations
+	// On Linux and Windows, the agent runs with elevated privileges and doesn't need them
+	var adminUser, adminPassword string
+	var err error
+	if runtime.GOOS == "darwin" {
+		adminUser, adminPassword, err = h.config.GetServiceCredentials()
+		if err != nil {
+			response.Response = fmt.Sprintf("unable to obtain service account credentials: %s", err.Error())
+			return response, errors.New(response.Response)
+		}
 	}
 
 	userInfo := osActions.UserInfo{


### PR DESCRIPTION
Service account credentials are only required on macOS for FileVault operations.
On Linux and Windows, the agent runs with elevated privileges (root/SYSTEM) and
doesn't need separate service account credentials for user management operations.

Changes:
- userAdd: Added platform check - only calls GetServiceCredentials() on macOS
- userDelete: Added platform check - only calls GetServiceCredentials() on macOS
- userUnlock: Added platform check - only calls GetServiceCredentials() on macOS
- userLock: Removed service account requirement (not needed on any platform)
- userAdmin: Removed service account requirement (not needed on any platform)

Fixes #15

Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/UnifyEM/UnifyEM/tree/claude/issue-15-20251206-0819) | [View job run](https://github.com/UnifyEM/UnifyEM/actions/runs/19985811051