### PR TITLE
feat: add tag support to uem-cli agent get command

### DIFF
--- a/cli/functions/agent/agent.go
+++ b/cli/functions/agent/agent.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -174,9 +176,11 @@ func agentGet(args []string, _ *util.NVPairs) error {
 	c := communications.New(login.Login())
 
 	// Check if argument is a tag
-	if len(args[0]) > 4 && args[0][:4] == "tag=" {
-		tag := args[0][4:]
-		display.ErrorWrapper(display.AnyResp(c.Get(schema.EndpointAgent + "/by-tag/" + tag)))
+	if tag, hasPrefix := strings.CutPrefix(args[0], "tag="); hasPrefix {
+		if tag == "" {
+			return errors.New("tag value cannot be empty")
+		}
+		display.ErrorWrapper(display.AnyResp(c.Get(schema.EndpointAgent + "/by-tag/" + url.PathEscape(tag))))
 		return nil
 	}
 
@@ -248,10 +252,12 @@ func agentAddUsers(args []string) error {
 		return errors.New("agent ID or tag=<tag> and at least one user are required")
 	}
 	c := communications.New(login.Login())
-	if len(args) > 0 && len(args[0]) > 4 && args[0][:4] == "tag=" {
-		tag := args[0][4:]
+	if tag, hasPrefix := strings.CutPrefix(args[0], "tag="); hasPrefix {
+		if tag == "" {
+			return errors.New("tag value cannot be empty")
+		}
 		// Query agents by tag
-		_, body, err := c.Get(schema.EndpointAgent + "/by-tag/" + tag)
+		_, body, err := c.Get(schema.EndpointAgent + "/by-tag/" + url.PathEscape(tag))
 		if err != nil {
 			return fmt.Errorf("failed to query agents by tag: %v", err)
 		}
@@ -286,10 +292,12 @@ func agentRemoveUsers(args []string) error {
 		return errors.New("agent ID or tag=<tag> and at least one user are required")
 	}
 	c := communications.New(login.Login())
-	if len(args) > 0 && len(args[0]) > 4 && args[0][:4] == "tag=" {
-		tag := args[0][4:]
+	if tag, hasPrefix := strings.CutPrefix(args[0], "tag="); hasPrefix {
+		if tag == "" {
+			return errors.New("tag value cannot be empty")
+		}
 		// Query agents by tag
-		_, body, err := c.Get(schema.EndpointAgent + "/by-tag/" + tag)
+		_, body, err := c.Get(schema.EndpointAgent + "/by-tag/" + url.PathEscape(tag))
 		if err != nil {
 			return fmt.Errorf("failed to query agents by tag: %v", err)
 		}

--- a/cli/functions/agent/agent.go
+++ b/cli/functions/agent/agent.go
@@ -43,9 +43,9 @@ func Register() *cobra.Command {
 	})
 
 	cmd.AddCommand(&cobra.Command{
-		Use:   "get <agent_id>",
+		Use:   "get <agent_id>|tag=<tag>",
 		Short: "get agent",
-		Long:  "get information about the agent",
+		Long:  "get information about the agent or all agents with a tag",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return agentGet(args, util.NewNVPairs(args))
 		},
@@ -168,10 +168,18 @@ func agentList(_ []string, _ *util.NVPairs) error {
 
 func agentGet(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("agent ID is required")
+		return errors.New("agent ID or tag=<tag> is required")
 	}
 
 	c := communications.New(login.Login())
+
+	// Check if argument is a tag
+	if len(args[0]) > 4 && args[0][:4] == "tag=" {
+		tag := args[0][4:]
+		display.ErrorWrapper(display.AnyResp(c.Get(schema.EndpointAgent + "/by-tag/" + tag)))
+		return nil
+	}
+
 	display.ErrorWrapper(display.AnyResp(c.Get(schema.EndpointAgent + "/" + args[0])))
 	return nil
 }


### PR DESCRIPTION
Allow `agent get tag=<tag>` to retrieve all agents matching a tag, consistent with the pattern used by other commands (user-add, user-remove). Routes to the existing /by-tag/{tag} server endpoint.

Fixes #26