### PR TITLE
fix: ensure EC keypairs generated before console-mode install operations

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -98,6 +98,13 @@ func console() int {
 		return 1
 	}
 
+	// Ensure EC keypairs exist so that credential encryption works during install
+	// and other console-mode operations. Non-fatal: SetServiceCredentials will
+	// produce a clear error if the key is still unavailable.
+	if err = ensureECKeys(conf, logger); err != nil {
+		fmt.Printf("Warning: could not ensure EC keypairs: %v\n", err)
+	}
+
 	switch strings.ToLower(os.Args[1]) {
 
 	case "install":


### PR DESCRIPTION
Fixes #25

Adds a call to `ensureECKeys()` in `console()` (`agent/main.go`) so that EC keypairs are available on disk before installer operations like `ServiceAccount()` attempt to use them for credential encryption. Previously `ensureECKeys()` was only called in `startService()`, which runs in a separate OS process — too late for the installer process to use the generated keys.

Generated with [Claude Code](https://claude.ai/code)