### PR TITLE
fix(agent): recover from corrupted config and add backup file

### DIFF
--- a/agent/global/backup.go
+++ b/agent/global/backup.go
@@ -92,6 +92,8 @@ func ReadBackup() (*schema.BackupConfig, error) {
 
 		var backup schema.BackupConfig
 		if err := json.Unmarshal(data, &backup); err != nil {
+			// Rename corrupt backup so it stops causing warnings on every restart
+			_ = os.Rename(path, path+".bak")
 			lastErr = err
 			continue
 		}

--- a/agent/global/backup.go
+++ b/agent/global/backup.go
@@ -56,11 +56,17 @@ func WriteBackup(conf *AgentConfig) error {
 
 	var lastErr error
 	for _, path := range UnixBackupFiles {
-		if writeErr := os.WriteFile(path, data, 0600); writeErr == nil {
-			return nil
-		} else {
+		tmp := path + ".tmp"
+		if writeErr := os.WriteFile(tmp, data, 0600); writeErr != nil {
 			lastErr = writeErr
+			continue
 		}
+		if renameErr := os.Rename(tmp, path); renameErr != nil {
+			_ = os.Remove(tmp)
+			lastErr = renameErr
+			continue
+		}
+		return nil
 	}
 
 	return lastErr
@@ -74,25 +80,26 @@ func ReadBackup() (*schema.BackupConfig, error) {
 		return nil, nil
 	}
 
+	var lastErr error
 	for _, path := range UnixBackupFiles {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
+			if !os.IsNotExist(err) {
+				lastErr = err
 			}
-			return nil, err
+			continue
 		}
 
 		var backup schema.BackupConfig
 		if err := json.Unmarshal(data, &backup); err != nil {
-			return nil, err
+			lastErr = err
+			continue
 		}
 
 		return &backup, nil
 	}
 
-	// No backup file found — not an error
-	return nil, nil
+	return nil, lastErr
 }
 
 // RestoreFromBackup copies non-empty fields from backup.Agent into conf.AP.

--- a/agent/global/backup.go
+++ b/agent/global/backup.go
@@ -1,0 +1,136 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package global
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+
+	"github.com/UnifyEM/UnifyEM/common/schema"
+)
+
+// UnixBackupFiles lists candidate paths for uem-backup.conf, parallel to UnixConfigFiles.
+var UnixBackupFiles = []string{
+	"/etc/uem-backup.conf",
+	"/usr/local/etc/uem-backup.conf",
+	"/var/root/uem-backup.conf",
+}
+
+// WriteBackup persists the agent's non-regeneratable identity fields to the
+// first writable path in UnixBackupFiles. It is a no-op if AgentID is empty
+// or on Windows (which uses the registry for persistence).
+// File permissions are set to 0600 to restrict access to root/owner only.
+func WriteBackup(conf *AgentConfig) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
+	agentID := conf.AP.Get(ConfigAgentID).String()
+	if agentID == "" {
+		// Nothing worth backing up yet
+		return nil
+	}
+
+	backup := schema.BackupConfig{
+		Agent: &schema.AgentBackup{
+			AgentID:         agentID,
+			ServerURL:       conf.AP.Get(ConfigServerURL).String(),
+			RefreshToken:    conf.AP.Get(ConfigRefreshToken).String(),
+			ServerPublicSig: conf.AP.Get(ConfigServerPublicSig).String(),
+			ServerPublicEnc: conf.AP.Get(ConfigServerPublicEnc).String(),
+			ECPrivateSig:    conf.AP.Get(ConfigAgentECPrivateSig).String(),
+			ECPublicSig:     conf.AP.Get(ConfigAgentECPublicSig).String(),
+			ECPrivateEnc:    conf.AP.Get(ConfigAgentECPrivateEnc).String(),
+			ECPublicEnc:     conf.AP.Get(ConfigAgentECPublicEnc).String(),
+		},
+	}
+
+	data, err := json.MarshalIndent(backup, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for _, path := range UnixBackupFiles {
+		if writeErr := os.WriteFile(path, data, 0600); writeErr == nil {
+			return nil
+		} else {
+			lastErr = writeErr
+		}
+	}
+
+	return lastErr
+}
+
+// ReadBackup reads and unmarshals the first backup file found in UnixBackupFiles.
+// Returns nil, nil if no backup file exists or on Windows — not treated as an error.
+// Returns an error only if a file is found but cannot be read or parsed.
+func ReadBackup() (*schema.BackupConfig, error) {
+	if runtime.GOOS == "windows" {
+		return nil, nil
+	}
+
+	for _, path := range UnixBackupFiles {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		var backup schema.BackupConfig
+		if err := json.Unmarshal(data, &backup); err != nil {
+			return nil, err
+		}
+
+		return &backup, nil
+	}
+
+	// No backup file found — not an error
+	return nil, nil
+}
+
+// RestoreFromBackup copies non-empty fields from backup.Agent into conf.AP.
+// Returns true if the agent identity (AgentID) was successfully restored.
+// Returns false if backup is nil, backup.Agent is nil, or AgentID is empty.
+func RestoreFromBackup(conf *AgentConfig, backup *schema.BackupConfig) bool {
+	if backup == nil || backup.Agent == nil || backup.Agent.AgentID == "" {
+		return false
+	}
+
+	a := backup.Agent
+
+	conf.AP.Set(ConfigAgentID, a.AgentID)
+
+	if a.ServerURL != "" {
+		conf.AP.Set(ConfigServerURL, a.ServerURL)
+	}
+	if a.RefreshToken != "" {
+		conf.AP.Set(ConfigRefreshToken, a.RefreshToken)
+	}
+	if a.ServerPublicSig != "" {
+		conf.AP.Set(ConfigServerPublicSig, a.ServerPublicSig)
+	}
+	if a.ServerPublicEnc != "" {
+		conf.AP.Set(ConfigServerPublicEnc, a.ServerPublicEnc)
+	}
+	if a.ECPrivateSig != "" {
+		conf.AP.Set(ConfigAgentECPrivateSig, a.ECPrivateSig)
+	}
+	if a.ECPublicSig != "" {
+		conf.AP.Set(ConfigAgentECPublicSig, a.ECPublicSig)
+	}
+	if a.ECPrivateEnc != "" {
+		conf.AP.Set(ConfigAgentECPrivateEnc, a.ECPrivateEnc)
+	}
+	if a.ECPublicEnc != "" {
+		conf.AP.Set(ConfigAgentECPublicEnc, a.ECPublicEnc)
+	}
+
+	return true
+}

--- a/agent/global/config.go
+++ b/agent/global/config.go
@@ -47,6 +47,13 @@ func Config() (*AgentConfig, error) {
 	// Set constraints, including default values
 	c.AC, c.AP = setDefaults(c.C)
 
+	// If agent identity is missing, attempt recovery from backup
+	if c.AP.Get(ConfigAgentID).String() == "" {
+		if backup, _ := ReadBackup(); backup != nil {
+			RestoreFromBackup(c, backup)
+		}
+	}
+
 	// Update the global lost flag when the config is loaded
 	Lost = c.AP.Get(ConfigLost).Bool()
 
@@ -99,7 +106,11 @@ func Config() (*AgentConfig, error) {
 }
 
 func (c *AgentConfig) Checkpoint() error {
-	return c.C.Checkpoint()
+	err := c.C.Checkpoint()
+	if err == nil {
+		_ = WriteBackup(c)
+	}
+	return err
 }
 
 // Delete the existing config file

--- a/agent/global/config.go
+++ b/agent/global/config.go
@@ -49,7 +49,9 @@ func Config() (*AgentConfig, error) {
 
 	// If agent identity is missing, attempt recovery from backup
 	if c.AP.Get(ConfigAgentID).String() == "" {
-		if backup, _ := ReadBackup(); backup != nil {
+		if backup, backupErr := ReadBackup(); backupErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: backup file found but unreadable: %v\n", backupErr)
+		} else if backup != nil {
 			RestoreFromBackup(c, backup)
 		}
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -372,23 +372,16 @@ func startService(optionalArgs ...bool) {
 
 	// Load the configuration and create a logger
 	conf, err = global.Config()
-	logger, logErr = newLogger()
-
-	// Check for a configuration error
 	if err != nil {
-		// Check if logger also failed
-		if logErr != nil {
-			fmt.Printf("Fatal logger error: %s\n", logErr.Error())
-		} else {
-			logger.Fatalf(8001, "unable to load or create config: %s", err.Error())
-		}
+		fmt.Printf("Fatal config error: %s\n", err.Error())
 		exit(1, false)
 	}
 
 	global.Debug = conf.AC.Get(schema.ConfigAgentDebug).Bool()
 
+	logger, logErr = newLogger()
 	if logErr != nil {
-		fmt.Printf("error creating logger: %v\n", err)
+		fmt.Printf("error creating logger: %v\n", logErr)
 		// Continue so that a logging issue doesn't prevent updates, etc.
 	}
 

--- a/common/schema/backup.go
+++ b/common/schema/backup.go
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package schema
+
+// BackupConfig is the top-level structure for uem-backup.conf.
+// Each sub-struct is a pointer so that omitempty suppresses absent sections.
+// This struct is intentionally extensible — add new sub-structs here as
+// additional components (CLI, server) require backup support.
+type BackupConfig struct {
+	Agent  *AgentBackup  `json:"agent,omitempty"`
+	CLI    *CLIBackup    `json:"cli,omitempty"`    // reserved for future CLI recovery data
+	Server *ServerBackup `json:"server,omitempty"` // reserved for future server recovery data
+}
+
+// AgentBackup holds the minimum fields required to recover an agent's
+// identity and re-authenticate with the server without re-registering.
+//
+// TODO: Add any additional non-regeneratable keys (e.g., hardware-bound
+// keys, CA hashes, service account credentials) as they are introduced.
+type AgentBackup struct {
+	AgentID         string `json:"agent_id,omitempty"`
+	ServerURL       string `json:"server_url,omitempty"`
+	RefreshToken    string `json:"refresh_token,omitempty"`
+	ServerPublicSig string `json:"server_public_sig,omitempty"`
+	ServerPublicEnc string `json:"server_public_enc,omitempty"`
+	ECPrivateSig    string `json:"ec_private_sig,omitempty"`
+	ECPublicSig     string `json:"ec_public_sig,omitempty"`
+	ECPrivateEnc    string `json:"ec_private_enc,omitempty"`
+	ECPublicEnc     string `json:"ec_public_enc,omitempty"`
+}
+
+// CLIBackup is reserved for future CLI recovery data.
+type CLIBackup struct{}
+
+// ServerBackup is reserved for future server recovery data.
+type ServerBackup struct{}

--- a/common/uconfig/options.go
+++ b/common/uconfig/options.go
@@ -49,8 +49,10 @@ func WithFindOrCreate(filenames []string) func(*UConfig) error {
 			if _, err := os.Stat(filename); err == nil {
 				if loadErr := c.Load(filename); loadErr != nil {
 					// File exists but failed to load — rename it as a backup before overwriting
-					_ = os.Rename(filename, filename+".bak")
-					return c.Save(filename)
+					if renameErr := os.Rename(filename, filename+".bak"); renameErr != nil {
+					return fmt.Errorf("config appears corrupt but cannot be renamed for backup: %w", renameErr)
+				}
+				return c.Save(filename)
 				}
 				return nil
 			}

--- a/common/uconfig/options.go
+++ b/common/uconfig/options.go
@@ -48,7 +48,8 @@ func WithFindOrCreate(filenames []string) func(*UConfig) error {
 		for _, filename := range filenames {
 			if _, err := os.Stat(filename); err == nil {
 				if loadErr := c.Load(filename); loadErr != nil {
-					// File exists but is corrupted - overwrite with defaults
+					// File exists but failed to load — rename it as a backup before overwriting
+					_ = os.Rename(filename, filename+".bak")
 					return c.Save(filename)
 				}
 				return nil

--- a/common/uconfig/options.go
+++ b/common/uconfig/options.go
@@ -47,7 +47,11 @@ func WithFindOrCreate(filenames []string) func(*UConfig) error {
 		// Iterate through the possible configuration files
 		for _, filename := range filenames {
 			if _, err := os.Stat(filename); err == nil {
-				return c.Load(filename)
+				if loadErr := c.Load(filename); loadErr != nil {
+					// File exists but is corrupted - overwrite with defaults
+					return c.Save(filename)
+				}
+				return nil
 			}
 		}
 

--- a/common/version.go
+++ b/common/version.go
@@ -6,6 +6,6 @@
 package common
 
 const (
-	Version = "0.0.50"
-	Build   = 96
+	Version = "0.0.51"
+	Build   = 97
 )


### PR DESCRIPTION
## Summary

- **Panic fix**: `newLogger()` was called before checking if `Config()` succeeded, causing a nil pointer dereference on `conf.AC` when the config failed to load for any reason (e.g. corrupted file, permission error)
- **Corrupted config recovery**: `WithFindOrCreate` now overwrites a corrupt config file (e.g. all null bytes) with defaults instead of propagating the load error as fatal
- **Bootstrap backup**: Introduces `/etc/uem-backup.conf` so a corrupted or missing `uem-agent.conf` can be recovered with the agent's existing server identity, avoiding re-registration as a new endpoint

## Details

### Panic fix (`agent/main.go`)
Moved `newLogger()` to after the `Config()` error check. If config fails, the error is printed to stdout and the process exits cleanly. Also fixed a pre-existing bug where `logErr` was printing `err` instead of `logErr`.

### Corrupted config (`common/uconfig/options.go`)
If a file exists but fails to load (e.g. null bytes from a crash mid-write), `WithFindOrCreate` now overwrites it with defaults rather than returning a fatal error.

### Backup file (`common/schema/backup.go`, `agent/global/backup.go`)
- `BackupConfig` struct with `Agent`, `CLI`, and `Server` pointer sub-structs (`omitempty`) — extensible for future components
- `AgentBackup` stores: `agent_id`, `server_url`, `refresh_token`, agent EC keypairs (sig + enc, private + public), and server public keys
- Written to `/etc/uem-backup.conf` (0600) on every successful `Checkpoint()` when `agent_id` is set
- On startup, if `agent_id` is missing from the loaded config, the backup is read and identity fields are restored before proceeding
- No-op on Windows (registry provides equivalent persistence)

## Test plan

- [ ] Deploy to a Linux agent, verify `/etc/uem-backup.conf` is created after registration
- [ ] Corrupt `/etc/uem-agent.conf` with null bytes, restart agent — verify it recovers identity from backup and reconnects without re-registering
- [ ] Delete `/etc/uem-agent.conf`, restart agent — verify same recovery behavior
- [ ] Delete both files, restart agent — verify clean fresh-start behavior (loops retrying registration)
- [ ] Verify Windows agent is unaffected (registry path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)