### PR TITLE
CLI self-signed certificate acceptance (TOFU)

### DIFF
--- a/cli/certstore/certstore.go
+++ b/cli/certstore/certstore.go
@@ -1,0 +1,101 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package certstore
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const certFile = ".uemcert"
+
+// Fingerprint computes the SHA-256 fingerprint of a DER-encoded certificate.
+func Fingerprint(cert *x509.Certificate) string {
+	hash := sha256.Sum256(cert.Raw)
+	return fmt.Sprintf("%X", hash)
+}
+
+// FormatCertDetails returns a human-readable summary of a certificate.
+func FormatCertDetails(cert *x509.Certificate) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  Subject:     %s\n", cert.Subject))
+	b.WriteString(fmt.Sprintf("  Issuer:      %s\n", cert.Issuer))
+	b.WriteString(fmt.Sprintf("  Fingerprint: %s\n", Fingerprint(cert)))
+	b.WriteString(fmt.Sprintf("  Not Before:  %s\n", cert.NotBefore.Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("  Not After:   %s\n", cert.NotAfter.Format(time.RFC3339)))
+	if len(cert.DNSNames) > 0 {
+		b.WriteString(fmt.Sprintf("  DNS Names:   %s\n", strings.Join(cert.DNSNames, ", ")))
+	}
+	return b.String()
+}
+
+// certFilePath returns the full path to ~/.uemcert.
+func certFilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	return filepath.Join(homeDir, certFile), nil
+}
+
+// IsTrusted checks whether the given host and fingerprint are stored in ~/.uemcert.
+func IsTrusted(host, fingerprint string) (bool, error) {
+	path, err := certFilePath()
+	if err != nil {
+		return false, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[0] == host && parts[1] == fingerprint {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
+}
+
+// Store appends a host and fingerprint entry to ~/.uemcert.
+func Store(host, fingerprint string) error {
+	path, err := certFilePath()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to open %s for writing: %w", path, err)
+	}
+	defer f.Close()
+
+	_, err = fmt.Fprintf(f, "%s %s\n", host, fingerprint)
+	if err != nil {
+		return fmt.Errorf("unable to write to %s: %w", path, err)
+	}
+	return nil
+}

--- a/cli/certstore/certstore.go
+++ b/cli/certstore/certstore.go
@@ -80,7 +80,8 @@ func IsTrusted(host, fingerprint string) (bool, error) {
 	return false, scanner.Err()
 }
 
-// Store appends a host and fingerprint entry to ~/.uemcert.
+// Store upserts a host and fingerprint entry in ~/.uemcert.
+// If the host already has an entry, it is replaced. Otherwise, a new entry is appended.
 // It uses atomic write (temp file + rename) to avoid corruption from concurrent access.
 func Store(host, fingerprint string) error {
 	path, err := certFilePath()
@@ -94,10 +95,20 @@ func Store(host, fingerprint string) error {
 		return err
 	}
 
-	// Append the new entry
-	existing = append(existing, fmt.Sprintf("%s %s", host, fingerprint))
+	// Remove any existing entry for this host
+	var kept []string
+	for _, line := range existing {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) == 2 && parts[0] == host {
+			continue
+		}
+		kept = append(kept, line)
+	}
 
-	return atomicWriteLines(path, existing)
+	// Append the new entry
+	kept = append(kept, fmt.Sprintf("%s %s", host, fingerprint))
+
+	return atomicWriteLines(path, kept)
 }
 
 // Remove deletes all entries for the given host from ~/.uemcert.
@@ -129,6 +140,35 @@ func Remove(host string) (bool, error) {
 	}
 
 	return true, atomicWriteLines(path, kept)
+}
+
+// Entry represents a single pinned certificate entry.
+type Entry struct {
+	Host        string
+	Fingerprint string
+}
+
+// List returns all pinned certificate entries from ~/.uemcert.
+func List() ([]Entry, error) {
+	path, err := certFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	lines, err := readLines(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []Entry
+	for _, line := range lines {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		entries = append(entries, Entry{Host: parts[0], Fingerprint: parts[1]})
+	}
+	return entries, nil
 }
 
 // readLines reads non-empty, non-comment lines from the cert file.

--- a/cli/certstore/certstore.go
+++ b/cli/certstore/certstore.go
@@ -81,21 +81,117 @@ func IsTrusted(host, fingerprint string) (bool, error) {
 }
 
 // Store appends a host and fingerprint entry to ~/.uemcert.
+// It uses atomic write (temp file + rename) to avoid corruption from concurrent access.
 func Store(host, fingerprint string) error {
 	path, err := certFilePath()
 	if err != nil {
 		return err
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	// Read existing content
+	existing, err := readLines(path)
 	if err != nil {
-		return fmt.Errorf("unable to open %s for writing: %w", path, err)
+		return err
+	}
+
+	// Append the new entry
+	existing = append(existing, fmt.Sprintf("%s %s", host, fingerprint))
+
+	return atomicWriteLines(path, existing)
+}
+
+// Remove deletes all entries for the given host from ~/.uemcert.
+// Returns true if any entries were removed.
+func Remove(host string) (bool, error) {
+	path, err := certFilePath()
+	if err != nil {
+		return false, err
+	}
+
+	lines, err := readLines(path)
+	if err != nil {
+		return false, err
+	}
+
+	var kept []string
+	removed := false
+	for _, line := range lines {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) == 2 && parts[0] == host {
+			removed = true
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	if !removed {
+		return false, nil
+	}
+
+	return true, atomicWriteLines(path, kept)
+}
+
+// readLines reads non-empty, non-comment lines from the cert file.
+// Returns nil (not an error) if the file does not exist.
+func readLines(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to open %s: %w", path, err)
 	}
 	defer f.Close()
 
-	_, err = fmt.Fprintf(f, "%s %s\n", host, fingerprint)
-	if err != nil {
-		return fmt.Errorf("unable to write to %s: %w", path, err)
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lines = append(lines, line)
 	}
+	return lines, scanner.Err()
+}
+
+// atomicWriteLines writes lines to a temp file and renames it into place.
+func atomicWriteLines(path string, lines []string) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".uemcert-tmp-*")
+	if err != nil {
+		return fmt.Errorf("unable to create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	// Ensure cleanup on failure
+	success := false
+	defer func() {
+		if !success {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("unable to set permissions on temp file: %w", err)
+	}
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(tmp, line); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("unable to write to temp file: %w", err)
+		}
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("unable to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("unable to rename temp file: %w", err)
+	}
+
+	success = true
 	return nil
 }

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -254,6 +254,60 @@ func TestRemovePreservesOtherEntries(t *testing.T) {
 	}
 }
 
+func TestStoreDeduplicates(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	host := "server.example.com:443"
+	fp1 := "FINGERPRINT_ONE"
+	fp2 := "FINGERPRINT_TWO"
+
+	// Store initial entry
+	if err := Store(host, fp1); err != nil {
+		t.Fatalf("unexpected error storing: %v", err)
+	}
+
+	// Store again with different fingerprint (simulates cert rotation)
+	if err := Store(host, fp2); err != nil {
+		t.Fatalf("unexpected error storing: %v", err)
+	}
+
+	// Old fingerprint should NOT be trusted
+	trusted, err := IsTrusted(host, fp1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("old fingerprint should not be trusted after upsert")
+	}
+
+	// New fingerprint should be trusted
+	trusted, err = IsTrusted(host, fp2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !trusted {
+		t.Fatal("new fingerprint should be trusted after upsert")
+	}
+
+	// Verify only one entry exists for this host
+	path := filepath.Join(tmpDir, certFile)
+	lines, err := readLines(path)
+	if err != nil {
+		t.Fatalf("unexpected error reading lines: %v", err)
+	}
+	count := 0
+	for _, line := range lines {
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) == 2 && parts[0] == host {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 entry for host, got %d", count)
+	}
+}
+
 func TestStoreMultiple(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -76,7 +77,7 @@ func TestFormatCertDetails(t *testing.T) {
 
 	// Check that key fields are present
 	for _, expected := range []string{"Subject:", "Issuer:", "Fingerprint:", "Not Before:", "Not After:", "DNS Names:"} {
-		if !containsString(details, expected) {
+		if !strings.Contains(details, expected) {
 			t.Errorf("expected %q in cert details", expected)
 		}
 	}
@@ -186,15 +187,3 @@ func TestStoreMultiple(t *testing.T) {
 	}
 }
 
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -157,6 +157,103 @@ func TestIsTrustedMissingFile(t *testing.T) {
 	}
 }
 
+func TestRemove(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	host := "server.example.com:443"
+	fp := "AABBCCDD0011223344556677889900AABBCCDD0011223344556677889900AABB"
+
+	// Remove from non-existent file should return false
+	removed, err := Remove(host)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Fatal("should not report removal when file does not exist")
+	}
+
+	// Store and then remove
+	if err := Store(host, fp); err != nil {
+		t.Fatalf("unexpected error storing: %v", err)
+	}
+	removed, err = Remove(host)
+	if err != nil {
+		t.Fatalf("unexpected error removing: %v", err)
+	}
+	if !removed {
+		t.Fatal("should report removal")
+	}
+
+	// Should no longer be trusted
+	trusted, err := IsTrusted(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("should not be trusted after removal")
+	}
+
+	// Remove again should return false
+	removed, err = Remove(host)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed {
+		t.Fatal("should not report removal when already removed")
+	}
+}
+
+func TestRemovePreservesOtherEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	if err := Store("host1:443", "FP1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := Store("host2:443", "FP2"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := Store("host3:443", "FP3"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Remove host2
+	removed, err := Remove("host2:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !removed {
+		t.Fatal("should report removal")
+	}
+
+	// host1 and host3 should still be trusted
+	for _, tc := range []struct {
+		host string
+		fp   string
+	}{
+		{"host1:443", "FP1"},
+		{"host3:443", "FP3"},
+	} {
+		trusted, err := IsTrusted(tc.host, tc.fp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !trusted {
+			t.Fatalf("%s should still be trusted", tc.host)
+		}
+	}
+
+	// host2 should not be trusted
+	trusted, err := IsTrusted("host2:443", "FP2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("host2 should not be trusted after removal")
+	}
+}
+
 func TestStoreMultiple(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -1,0 +1,200 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package certstore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateTestCert creates a self-signed certificate for testing.
+func generateTestCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+			CommonName:   "test.example.com",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+		DNSNames:  []string{"test.example.com", "localhost"},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return cert
+}
+
+func TestFingerprint(t *testing.T) {
+	cert := generateTestCert(t)
+	fp := Fingerprint(cert)
+	if fp == "" {
+		t.Fatal("fingerprint should not be empty")
+	}
+	if len(fp) != 64 {
+		t.Fatalf("expected 64 hex characters, got %d", len(fp))
+	}
+
+	// Same cert should produce same fingerprint
+	fp2 := Fingerprint(cert)
+	if fp != fp2 {
+		t.Fatal("fingerprint should be deterministic")
+	}
+}
+
+func TestFormatCertDetails(t *testing.T) {
+	cert := generateTestCert(t)
+	details := FormatCertDetails(cert)
+	if details == "" {
+		t.Fatal("cert details should not be empty")
+	}
+
+	// Check that key fields are present
+	for _, expected := range []string{"Subject:", "Issuer:", "Fingerprint:", "Not Before:", "Not After:", "DNS Names:"} {
+		if !containsString(details, expected) {
+			t.Errorf("expected %q in cert details", expected)
+		}
+	}
+}
+
+func TestStoreAndIsTrusted(t *testing.T) {
+	// Use a temp directory as home
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	host := "server.example.com:443"
+	fp := "AABBCCDD0011223344556677889900AABBCCDD0011223344556677889900AABB"
+
+	// Should not be trusted initially
+	trusted, err := IsTrusted(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("should not be trusted before storing")
+	}
+
+	// Store it
+	err = Store(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error storing: %v", err)
+	}
+
+	// Should now be trusted
+	trusted, err = IsTrusted(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !trusted {
+		t.Fatal("should be trusted after storing")
+	}
+
+	// Different host should not be trusted
+	trusted, err = IsTrusted("other.example.com:443", fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("different host should not be trusted")
+	}
+
+	// Different fingerprint should not be trusted
+	trusted, err = IsTrusted(host, "DIFFERENT_FINGERPRINT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("different fingerprint should not be trusted")
+	}
+
+	// Verify file permissions
+	path := filepath.Join(tmpDir, certFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("unable to stat cert file: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected file permissions 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestIsTrustedMissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	trusted, err := IsTrusted("host:443", "FP")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("should not be trusted when file does not exist")
+	}
+}
+
+func TestStoreMultiple(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	entries := []struct {
+		host string
+		fp   string
+	}{
+		{"host1:443", "FP1"},
+		{"host2:8443", "FP2"},
+		{"host3:443", "FP3"},
+	}
+
+	for _, e := range entries {
+		if err := Store(e.host, e.fp); err != nil {
+			t.Fatalf("unexpected error storing %s: %v", e.host, err)
+		}
+	}
+
+	for _, e := range entries {
+		trusted, err := IsTrusted(e.host, e.fp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !trusted {
+			t.Fatalf("%s should be trusted", e.host)
+		}
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -186,4 +186,3 @@ func TestStoreMultiple(t *testing.T) {
 		}
 	}
 }
-

--- a/cli/communications/new.go
+++ b/cli/communications/new.go
@@ -11,7 +11,8 @@ import "github.com/UnifyEM/UnifyEM/cli/global"
 var _ global.Comms = &Communications{}
 
 type Communications struct {
-	token string
+	token           string
+	freshlyAccepted map[string]bool // hosts whose certs were accepted this session
 }
 
 // New returns a new Communications object and optionally accepts a token

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -48,7 +49,7 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 	if err != nil {
 		// Check if this is an untrusted certificate error
 		var certErr *UntrustedCertError
-		if matchUntrustedCertError(err, &certErr) {
+		if errors.As(err, &certErr) {
 			// Prompt the user to accept the certificate
 			accepted, promptErr := promptUserForCert(certErr.Cert, certErr.Host)
 			if promptErr != nil {
@@ -182,45 +183,6 @@ func promptUserForCert(cert *x509.Certificate, host string) (bool, error) {
 
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	return answer == "yes" || answer == "y", nil
-}
-
-// matchUntrustedCertError unwraps err to find an *UntrustedCertError.
-// Returns true if found, setting target to the matched error.
-func matchUntrustedCertError(err error, target **UntrustedCertError) bool {
-	if err == nil {
-		return false
-	}
-	// The error is typically wrapped by net/http and tls layers, so we
-	// need to walk the chain. errors.As won't always work because
-	// some wrapping in net/url uses opaque string formatting. We do a
-	// recursive unwrap plus a type-switch approach.
-	type unwrapper interface {
-		Unwrap() error
-	}
-	type unwrapperSlice interface {
-		Unwrap() []error
-	}
-
-	switch e := err.(type) {
-	case *UntrustedCertError:
-		*target = e
-		return true
-	case unwrapper:
-		return matchUntrustedCertError(e.Unwrap(), target)
-	case unwrapperSlice:
-		for _, inner := range e.Unwrap() {
-			if matchUntrustedCertError(inner, target) {
-				return true
-			}
-		}
-	}
-
-	// Last resort: check if it's a *url.Error wrapping our error
-	if urlErr, ok := err.(*url.Error); ok {
-		return matchUntrustedCertError(urlErr.Err, target)
-	}
-
-	return false
 }
 
 // hostFromURL extracts the host:port from a URL string.

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/UnifyEM/UnifyEM/cli/certstore"
 	"github.com/UnifyEM/UnifyEM/cli/global"
@@ -154,6 +155,12 @@ func (c *Communications) buildHTTPClient(host string) *http.Client {
 				return fmt.Errorf("failed to check certificate store: %w", err)
 			}
 			if trusted {
+				if time.Now().After(cert.NotAfter) {
+					// Pinned cert has expired — treat as untrusted so user is prompted to re-accept
+					fmt.Printf("\nWARNING: The pinned certificate for %s has expired (expired %s).\n",
+						host, cert.NotAfter.Format(time.RFC3339))
+					return &UntrustedCertError{Cert: cert, Host: host}
+				}
 				return nil
 			}
 

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -66,6 +66,12 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 				return 0, nil, fmt.Errorf("failed to store certificate: %w", storeErr)
 			}
 
+			// Mark as freshly accepted so the retry skips the expiry check
+			if c.freshlyAccepted == nil {
+				c.freshlyAccepted = make(map[string]bool)
+			}
+			c.freshlyAccepted[host] = true
+
 			// Retry with the now-trusted certificate
 			client = c.buildHTTPClient(host)
 			return c.doRequest(client, method, reqURL, payload)
@@ -155,7 +161,17 @@ func (c *Communications) buildHTTPClient(host string) *http.Client {
 				return fmt.Errorf("failed to check certificate store: %w", err)
 			}
 			if trusted {
-				if time.Now().After(cert.NotAfter) {
+				// Skip time validity checks if the user just explicitly accepted this cert
+				if c.freshlyAccepted[host] {
+					return nil
+				}
+				now := time.Now()
+				if now.Before(cert.NotBefore) {
+					fmt.Printf("\nWARNING: The pinned certificate for %s is not yet valid (valid from %s).\n",
+						host, cert.NotBefore.Format(time.RFC3339))
+					return &UntrustedCertError{Cert: cert, Host: host}
+				}
+				if now.After(cert.NotAfter) {
 					// Pinned cert has expired — treat as untrusted so user is prompted to re-accept
 					fmt.Printf("\nWARNING: The pinned certificate for %s has expired (expired %s).\n",
 						host, cert.NotAfter.Format(time.RFC3339))

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -6,22 +6,77 @@
 package communications
 
 import (
+	"bufio"
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 
+	"github.com/UnifyEM/UnifyEM/cli/certstore"
 	"github.com/UnifyEM/UnifyEM/cli/global"
 )
+
+// UntrustedCertError is returned when a server presents a certificate
+// that is neither trusted by the system roots nor stored in ~/.uemcert.
+type UntrustedCertError struct {
+	Cert *x509.Certificate
+	Host string
+}
+
+func (e *UntrustedCertError) Error() string {
+	return fmt.Sprintf("untrusted certificate from %s", e.Host)
+}
 
 // sendRequest is a lower level function that sends HTTP requests
 func (c *Communications) sendRequest(method, endpoint string, payload []byte) (int, []byte, error) {
 
 	// Build the request URL
-	url := fmt.Sprintf("%s%s", global.ServerURL, endpoint)
+	reqURL := fmt.Sprintf("%s%s", global.ServerURL, endpoint)
 
-	// Create a new HTTP request
-	httpReq, err := http.NewRequest(method, url, bytes.NewBuffer(payload))
+	// Extract host:port for certificate operations
+	host := hostFromURL(reqURL)
+
+	// Build the HTTP client with TLS certificate verification
+	client := c.buildHTTPClient(host)
+
+	code, body, err := c.doRequest(client, method, reqURL, payload)
+	if err != nil {
+		// Check if this is an untrusted certificate error
+		var certErr *UntrustedCertError
+		if matchUntrustedCertError(err, &certErr) {
+			// Prompt the user to accept the certificate
+			accepted, promptErr := promptUserForCert(certErr.Cert, certErr.Host)
+			if promptErr != nil {
+				return 0, nil, fmt.Errorf("failed to prompt for certificate acceptance: %w", promptErr)
+			}
+			if !accepted {
+				return 0, nil, fmt.Errorf("certificate rejected by user")
+			}
+
+			// Store the accepted fingerprint
+			fp := certstore.Fingerprint(certErr.Cert)
+			if storeErr := certstore.Store(host, fp); storeErr != nil {
+				return 0, nil, fmt.Errorf("failed to store certificate: %w", storeErr)
+			}
+
+			// Retry with the now-trusted certificate
+			client = c.buildHTTPClient(host)
+			return c.doRequest(client, method, reqURL, payload)
+		}
+		return 0, nil, err
+	}
+	return code, body, nil
+}
+
+// doRequest executes an HTTP request and returns status code, body, and error.
+func (c *Communications) doRequest(client *http.Client, method, reqURL string, payload []byte) (int, []byte, error) {
+
+	httpReq, err := http.NewRequest(method, reqURL, bytes.NewBuffer(payload))
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -36,8 +91,6 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
 
-	// Send the request
-	client := &http.Client{}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to send HTTP request: %w", err)
@@ -54,4 +107,134 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 	}
 
 	return resp.StatusCode, responseBody.Bytes(), nil
+}
+
+// buildHTTPClient creates an http.Client with custom TLS verification
+// that trusts certificates whose fingerprints are stored in ~/.uemcert.
+func (c *Communications) buildHTTPClient(host string) *http.Client {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("server presented no certificates")
+			}
+
+			cert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse server certificate: %w", err)
+			}
+
+			// First, try standard system root verification
+			roots, err := x509.SystemCertPool()
+			if err == nil && roots != nil {
+				opts := x509.VerifyOptions{
+					Roots:         roots,
+					Intermediates: x509.NewCertPool(),
+				}
+				// Add intermediate certs if present
+				for _, rawCert := range rawCerts[1:] {
+					intermediateCert, parseErr := x509.ParseCertificate(rawCert)
+					if parseErr == nil {
+						opts.Intermediates.AddCert(intermediateCert)
+					}
+				}
+				if _, verifyErr := cert.Verify(opts); verifyErr == nil {
+					return nil
+				}
+			}
+
+			// System verification failed — check the fingerprint store
+			fp := certstore.Fingerprint(cert)
+			trusted, err := certstore.IsTrusted(host, fp)
+			if err != nil {
+				return fmt.Errorf("failed to check certificate store: %w", err)
+			}
+			if trusted {
+				return nil
+			}
+
+			// Not trusted by any means — return a typed error for prompting
+			return &UntrustedCertError{Cert: cert, Host: host}
+		},
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// promptUserForCert displays certificate details and asks the user to accept or reject.
+func promptUserForCert(cert *x509.Certificate, host string) (bool, error) {
+	fmt.Printf("\nWARNING: The server at %s presented an untrusted certificate:\n\n", host)
+	fmt.Print(certstore.FormatCertDetails(cert))
+	fmt.Print("\nDo you want to trust this certificate? (yes/no): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "yes" || answer == "y", nil
+}
+
+// matchUntrustedCertError unwraps err to find an *UntrustedCertError.
+// Returns true if found, setting target to the matched error.
+func matchUntrustedCertError(err error, target **UntrustedCertError) bool {
+	if err == nil {
+		return false
+	}
+	// The error is typically wrapped by net/http and tls layers, so we
+	// need to walk the chain. errors.As won't always work because
+	// some wrapping in net/url uses opaque string formatting. We do a
+	// recursive unwrap plus a type-switch approach.
+	type unwrapper interface {
+		Unwrap() error
+	}
+	type unwrapperSlice interface {
+		Unwrap() []error
+	}
+
+	switch e := err.(type) {
+	case *UntrustedCertError:
+		*target = e
+		return true
+	case unwrapper:
+		return matchUntrustedCertError(e.Unwrap(), target)
+	case unwrapperSlice:
+		for _, inner := range e.Unwrap() {
+			if matchUntrustedCertError(inner, target) {
+				return true
+			}
+		}
+	}
+
+	// Last resort: check if it's a *url.Error wrapping our error
+	if urlErr, ok := err.(*url.Error); ok {
+		return matchUntrustedCertError(urlErr.Err, target)
+	}
+
+	return false
+}
+
+// hostFromURL extracts the host:port from a URL string.
+// If no port is specified, defaults based on scheme.
+func hostFromURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	host := parsed.Hostname()
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return host + ":" + port
 }

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -127,7 +127,10 @@ func (c *Communications) buildHTTPClient(host string) *http.Client {
 			// First, try standard system root verification
 			roots, err := x509.SystemCertPool()
 			if err == nil && roots != nil {
+				// Extract hostname without port for DNSName verification
+				dnsName, _, _ := strings.Cut(host, ":")
 				opts := x509.VerifyOptions{
+					DNSName:       dnsName,
 					Roots:         roots,
 					Intermediates: x509.NewCertPool(),
 				}

--- a/cli/communications/send_test.go
+++ b/cli/communications/send_test.go
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package communications
+
+import "testing"
+
+func TestHostFromURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		expected string
+	}{
+		{
+			name:     "https with explicit port",
+			rawURL:   "https://server.example.com:8443/api/v1/ping",
+			expected: "server.example.com:8443",
+		},
+		{
+			name:     "https without port",
+			rawURL:   "https://server.example.com/api/v1/ping",
+			expected: "server.example.com:443",
+		},
+		{
+			name:     "http without port",
+			rawURL:   "http://server.example.com/api/v1/ping",
+			expected: "server.example.com:80",
+		},
+		{
+			name:     "http with explicit port",
+			rawURL:   "http://server.example.com:9090/path",
+			expected: "server.example.com:9090",
+		},
+		{
+			name:     "localhost with port",
+			rawURL:   "https://localhost:443/test",
+			expected: "localhost:443",
+		},
+		{
+			name:     "IP address with port",
+			rawURL:   "https://192.168.1.1:8443/api",
+			expected: "192.168.1.1:8443",
+		},
+		{
+			name:     "IP address without port",
+			rawURL:   "https://192.168.1.1/api",
+			expected: "192.168.1.1:443",
+		},
+		{
+			name:     "no path",
+			rawURL:   "https://example.com",
+			expected: "example.com:443",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hostFromURL(tc.rawURL)
+			if got != tc.expected {
+				t.Errorf("hostFromURL(%q) = %q, want %q", tc.rawURL, got, tc.expected)
+			}
+		})
+	}
+}

--- a/cli/functions/cert/cert.go
+++ b/cli/functions/cert/cert.go
@@ -7,6 +7,7 @@ package cert
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -27,6 +28,16 @@ func Register() *cobra.Command {
 	}
 
 	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "list pinned certificates",
+		Long:  "display all pinned TLS certificates stored in ~/.uemcert",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listExec()
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
 		Use:   "remove <host:port>",
 		Short: "remove a pinned certificate",
 		Long:  "remove all pinned certificate entries for the given host:port from ~/.uemcert",
@@ -39,7 +50,34 @@ func Register() *cobra.Command {
 	return cmd
 }
 
+func listExec() error {
+	entries, err := certstore.List()
+	if err != nil {
+		return fmt.Errorf("failed to list certificates: %w", err)
+	}
+	if len(entries) == 0 {
+		fmt.Println("No pinned certificates found")
+		return nil
+	}
+	for _, e := range entries {
+		fmt.Printf("%-40s %s\n", e.Host, e.Fingerprint)
+	}
+	return nil
+}
+
+func validateHostPort(s string) error {
+	// Must contain exactly one colon separating non-empty host and port
+	host, port, found := strings.Cut(s, ":")
+	if !found || host == "" || port == "" {
+		return fmt.Errorf("invalid format %q: expected host:port", s)
+	}
+	return nil
+}
+
 func removeExec(host string) error {
+	if err := validateHostPort(host); err != nil {
+		return err
+	}
 	removed, err := certstore.Remove(host)
 	if err != nil {
 		return fmt.Errorf("failed to remove certificate: %w", err)

--- a/cli/functions/cert/cert.go
+++ b/cli/functions/cert/cert.go
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package cert
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/UnifyEM/UnifyEM/cli/certstore"
+)
+
+func Register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cert",
+		Short: "certificate management commands",
+		Long:  "manage pinned TLS certificates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("a subcommand is required\n")
+			}
+			return fmt.Errorf("unknown subcommand: %s\n", args[0])
+		},
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "remove <host:port>",
+		Short: "remove a pinned certificate",
+		Long:  "remove all pinned certificate entries for the given host:port from ~/.uemcert",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return removeExec(args[0])
+		},
+	})
+
+	return cmd
+}
+
+func removeExec(host string) error {
+	removed, err := certstore.Remove(host)
+	if err != nil {
+		return fmt.Errorf("failed to remove certificate: %w", err)
+	}
+	if !removed {
+		fmt.Printf("No pinned certificate found for %s\n", host)
+		return nil
+	}
+	fmt.Printf("Pinned certificate for %s removed\n", host)
+	return nil
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/UnifyEM/UnifyEM/cli/functions/agent"
+	"github.com/UnifyEM/UnifyEM/cli/functions/cert"
 	"github.com/UnifyEM/UnifyEM/cli/functions/cmd"
 	"github.com/UnifyEM/UnifyEM/cli/functions/events"
 	"github.com/UnifyEM/UnifyEM/cli/functions/files"
@@ -50,6 +51,7 @@ func main() {
 
 	// Add the functions
 	rootCmd.AddCommand(agent.Register())
+	rootCmd.AddCommand(cert.Register())
 	rootCmd.AddCommand(cmd.Register())
 	rootCmd.AddCommand(configCmd.Register())
 	rootCmd.AddCommand(events.Register())


### PR DESCRIPTION
## Summary
- SSH-style Trust-On-First-Use (TOFU) certificate acceptance via `~/.uemcert` fingerprint store
- SHA-256 fingerprint pinning over DER-encoded certs, scoped by `host:port`
- Interactive prompt shows Subject, Issuer, Fingerprint, validity dates, DNS SANs
- System roots tried first, fingerprint store as fallback

## Security fixes applied during QA
- Added hostname verification in system root TLS validation (`71ed758`)
- Replaced custom error unwrapper with `errors.As`, removed duplicate test helpers (`67a965c`)
- gofmt trailing newline cleanup (`8e0b4c4`)

## Security notes
- `.uemcert` created with `0600` permissions
- Non-interactive stdin → rejection (fails closed)
- No bypass flags — explicit user consent required

## Test plan
- [x] Build and static analysis clean
- [x] certstore unit tests pass
- [x] Security review passed
- [x] Multiple QA passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)