### PR TITLE
Recovery framework, service accounts, CLI improvements, and self-signed cert support

### DIFF
--- a/agent/communications/comms.go
+++ b/agent/communications/comms.go
@@ -7,6 +7,7 @@ package communications
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/UnifyEM/UnifyEM/agent/global"
 	"github.com/UnifyEM/UnifyEM/agent/queues"
@@ -20,6 +21,7 @@ type Communications struct {
 	requests            *queues.RequestQueue
 	responses           *queues.ResponseQueue
 	jwt                 string
+	recoveryMu          sync.Mutex
 	pendingRecoveryInfo string
 }
 
@@ -99,11 +101,15 @@ func (c *Communications) RetryRequired() bool {
 
 // SetPendingRecoveryInfo stores encrypted recovery info to be included in the next sync
 func (c *Communications) SetPendingRecoveryInfo(info string) {
+	c.recoveryMu.Lock()
+	defer c.recoveryMu.Unlock()
 	c.pendingRecoveryInfo = info
 }
 
 // takePendingRecoveryInfo returns and clears any pending recovery info
 func (c *Communications) takePendingRecoveryInfo() string {
+	c.recoveryMu.Lock()
+	defer c.recoveryMu.Unlock()
 	info := c.pendingRecoveryInfo
 	c.pendingRecoveryInfo = ""
 	return info

--- a/agent/communications/comms.go
+++ b/agent/communications/comms.go
@@ -14,12 +14,13 @@ import (
 )
 
 type Communications struct {
-	retryRequired bool
-	logger        interfaces.Logger
-	conf          *global.AgentConfig
-	requests      *queues.RequestQueue
-	responses     *queues.ResponseQueue
-	jwt           string
+	retryRequired       bool
+	logger              interfaces.Logger
+	conf                *global.AgentConfig
+	requests            *queues.RequestQueue
+	responses           *queues.ResponseQueue
+	jwt                 string
+	pendingRecoveryInfo string
 }
 
 func New(options ...func(*Communications) error) (*Communications, error) {
@@ -94,4 +95,16 @@ func (c *Communications) RetryRequired() bool {
 		return true
 	}
 	return false
+}
+
+// SetPendingRecoveryInfo stores encrypted recovery info to be included in the next sync
+func (c *Communications) SetPendingRecoveryInfo(info string) {
+	c.pendingRecoveryInfo = info
+}
+
+// takePendingRecoveryInfo returns and clears any pending recovery info
+func (c *Communications) takePendingRecoveryInfo() string {
+	info := c.pendingRecoveryInfo
+	c.pendingRecoveryInfo = ""
+	return info
 }

--- a/agent/communications/register.go
+++ b/agent/communications/register.go
@@ -46,12 +46,16 @@ func (c *Communications) register() (string, error) {
 	clientPublicSig := c.conf.AP.Get(global.ConfigAgentECPublicSig).String()
 	clientPublicEnc := c.conf.AP.Get(global.ConfigAgentECPublicEnc).String()
 
+	// Get the friendly name set at install time (cleared after successful registration)
+	friendlyName := c.conf.AP.Get(global.ConfigFriendlyName).String()
+
 	req := schema.AgentRegisterRequest{
 		Token:           regToken,
 		Version:         global.Version,
 		Build:           global.Build,
 		ClientPublicSig: clientPublicSig,
 		ClientPublicEnc: clientPublicEnc,
+		FriendlyName:    friendlyName,
 	}
 
 	// Send the registration request
@@ -99,6 +103,13 @@ func (c *Communications) register() (string, error) {
 	if err != nil {
 		c.logger.Errorf(8017, "error checkpointing configuration: %s", err.Error())
 	}
+
+	// Clear the friendly name after successful registration (one-time use)
+	if friendlyName != "" {
+		c.conf.AP.Set(global.ConfigFriendlyName, "")
+		_ = c.conf.Checkpoint()
+	}
+
 	return c.jwt, nil
 }
 

--- a/agent/communications/sync.go
+++ b/agent/communications/sync.go
@@ -51,9 +51,10 @@ func (c *Communications) Sync() {
 
 	// Create a sync request to send to the server and include any queued responses
 	request := schema.AgentSyncRequest{
-		Version:   global.Version,
-		Build:     global.Build,
-		Responses: responses,
+		Version:      global.Version,
+		Build:        global.Build,
+		Responses:    responses,
+		RecoveryInfo: c.takePendingRecoveryInfo(),
 	}
 
 	// If lost mode is set, send an alert message
@@ -118,6 +119,12 @@ func (c *Communications) Sync() {
 			c.conf.SetServiceCredentialsEncrypted(serverResponse.ServiceCredentials)
 			c.logger.Info(8031, "received service account credentials from server", nil)
 		}
+	}
+
+	// Store recovery public key if provided
+	if serverResponse.RecoveryPublicKey != "" {
+		c.conf.AP.Set(global.ConfigRecoveryPublicKey, serverResponse.RecoveryPublicKey)
+		c.logger.Info(8032, "received recovery public key from server", nil)
 	}
 
 	// Checkpoint the configuration

--- a/agent/communications/sync.go
+++ b/agent/communications/sync.go
@@ -49,12 +49,15 @@ func (c *Communications) Sync() {
 	// Get a list of responses waiting to be sent to the server
 	responses := c.responses.ReadAll()
 
+	// Take any pending recovery info before sending — saved so it can be requeued on failure
+	recoveryInfo := c.takePendingRecoveryInfo()
+
 	// Create a sync request to send to the server and include any queued responses
 	request := schema.AgentSyncRequest{
 		Version:      global.Version,
 		Build:        global.Build,
 		Responses:    responses,
-		RecoveryInfo: c.takePendingRecoveryInfo(),
+		RecoveryInfo: recoveryInfo,
 	}
 
 	// If lost mode is set, send an alert message
@@ -73,6 +76,7 @@ func (c *Communications) Sync() {
 	if err != nil {
 		c.logger.Errorf(8024, "error sending sync request: %s", err.Error())
 		c.responses.ReQueue(responses)
+		c.SetPendingRecoveryInfo(recoveryInfo)
 		return
 	}
 
@@ -82,12 +86,14 @@ func (c *Communications) Sync() {
 	if err != nil {
 		c.logger.Errorf(8025, "error unmarshalling sync response: %s", err.Error())
 		c.responses.ReQueue(responses)
+		c.SetPendingRecoveryInfo(recoveryInfo)
 		return
 	}
 
 	if serverResponse.Code != 200 {
 		c.logger.Errorf(8026, "sync failed with code %d: %s", serverResponse.Code, serverResponse.Details)
 		c.responses.ReQueue(responses)
+		c.SetPendingRecoveryInfo(recoveryInfo)
 		return
 	}
 

--- a/agent/functions/reboot/reboot.go
+++ b/agent/functions/reboot/reboot.go
@@ -8,7 +8,6 @@ package reboot
 import (
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/global"
-	"github.com/UnifyEM/UnifyEM/agent/osActions"
 	"github.com/UnifyEM/UnifyEM/common/fields"
 	"github.com/UnifyEM/UnifyEM/common/interfaces"
 	"github.com/UnifyEM/UnifyEM/common/schema"
@@ -30,25 +29,20 @@ func New(config *global.AgentConfig, logger interfaces.Logger, comms *communicat
 
 func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error) {
 
-	// Create a response to the server
-	// This will only be sent if the reboot fails
 	response := schema.NewAgentResponse()
 	response.Cmd = request.Request
 	response.RequestID = request.RequestID
-	response.Response = "reboot failed"
-	response.Success = false
+	response.Response = "reboot initiated"
+	response.Success = true
+	response.PreShutdown = true
+	response.ShutdownType = "reboot"
 
-	// Assemble log fields
 	f := fields.NewFields(
 		fields.NewField("cmd", request.Request),
 		fields.NewField("requester", request.Requester),
 		fields.NewField("request_id", request.RequestID),
 	)
 
-	// Log the event
-	h.logger.Info(8210, "attempting reboot", f)
-
-	// Call the OS function
-	a := osActions.New(h.logger)
-	return response, a.Reboot()
+	h.logger.Info(8210, "reboot requested, syncing before reboot", f)
+	return response, nil
 }

--- a/agent/functions/shutdown/shutdown.go
+++ b/agent/functions/shutdown/shutdown.go
@@ -8,7 +8,6 @@ package shutdown
 import (
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/global"
-	"github.com/UnifyEM/UnifyEM/agent/osActions"
 	"github.com/UnifyEM/UnifyEM/common/fields"
 	"github.com/UnifyEM/UnifyEM/common/interfaces"
 	"github.com/UnifyEM/UnifyEM/common/schema"
@@ -30,25 +29,20 @@ func New(config *global.AgentConfig, logger interfaces.Logger, comms *communicat
 
 func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error) {
 
-	// Create a response to the server
-	// This will only be sent if the reboot fails
 	response := schema.NewAgentResponse()
 	response.Cmd = request.Request
 	response.RequestID = request.RequestID
-	response.Response = "shutdown failed"
-	response.Success = false
+	response.Response = "shutdown initiated"
+	response.Success = true
+	response.PreShutdown = true
+	response.ShutdownType = "shutdown"
 
-	// Assemble log fields
 	f := fields.NewFields(
 		fields.NewField("cmd", request.Request),
 		fields.NewField("requester", request.Requester),
 		fields.NewField("request_id", request.RequestID),
 	)
 
-	// Log the event
-	h.logger.Info(8210, "attempting shutdown", f)
-
-	// Call the OS function
-	a := osActions.New(h.logger)
-	return response, a.Shutdown()
+	h.logger.Info(8210, "shutdown requested, syncing before shutdown", f)
+	return response, nil
 }

--- a/agent/functions/userDelete/userDelete.go
+++ b/agent/functions/userDelete/userDelete.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/global"
@@ -89,14 +88,10 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 		h.logger.Info(8200, "user locked (macOS limitation)", f)
 		response.Success = true
 		if shutdown {
-			response.Response = fmt.Sprintf("successfully locked user %s (macOS does not support delete), shutdown in 30 seconds", username)
-			go func() {
-				time.Sleep(30 * time.Second)
-				h.logger.Info(8213, "initiating delayed shutdown after user delete", f)
-				if sErr := a.Shutdown(); sErr != nil {
-					h.logger.Error(8214, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
-				}
-			}()
+			response.Response = fmt.Sprintf("successfully locked user %s (macOS does not support delete), initiating shutdown", username)
+			response.PreShutdown = true
+			response.ShutdownType = "shutdown"
+			h.logger.Info(8213, "shutdown requested after user delete, syncing before shutdown", f)
 		} else {
 			response.Response = fmt.Sprintf("successfully locked user %s (macOS does not support delete)", username)
 		}
@@ -107,14 +102,10 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 	response.Success = true
 
 	if shutdown {
-		response.Response = fmt.Sprintf("successfully deleted user %s, shutdown in 30 seconds", username)
-		go func() {
-			time.Sleep(30 * time.Second)
-			h.logger.Info(8213, "initiating delayed shutdown after user delete", f)
-			if sErr := a.Shutdown(); sErr != nil {
-				h.logger.Error(8214, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
-			}
-		}()
+		response.Response = fmt.Sprintf("successfully deleted user %s, initiating shutdown", username)
+		response.PreShutdown = true
+		response.ShutdownType = "shutdown"
+		h.logger.Info(8213, "shutdown requested after user delete, syncing before shutdown", f)
 	} else {
 		response.Response = fmt.Sprintf("successfully deleted user %s", username)
 	}

--- a/agent/functions/userDelete/userDelete.go
+++ b/agent/functions/userDelete/userDelete.go
@@ -92,9 +92,9 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 			response.Response = fmt.Sprintf("successfully locked user %s (macOS does not support delete), shutdown in 30 seconds", username)
 			go func() {
 				time.Sleep(30 * time.Second)
-				h.logger.Info(8202, "initiating delayed shutdown after user delete", f)
+				h.logger.Info(8213, "initiating delayed shutdown after user delete", f)
 				if sErr := a.Shutdown(); sErr != nil {
-					h.logger.Error(8203, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
+					h.logger.Error(8214, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
 				}
 			}()
 		} else {
@@ -110,9 +110,9 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 		response.Response = fmt.Sprintf("successfully deleted user %s, shutdown in 30 seconds", username)
 		go func() {
 			time.Sleep(30 * time.Second)
-			h.logger.Info(8202, "initiating delayed shutdown after user delete", f)
+			h.logger.Info(8213, "initiating delayed shutdown after user delete", f)
 			if sErr := a.Shutdown(); sErr != nil {
-				h.logger.Error(8203, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
+				h.logger.Error(8214, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
 			}
 		}()
 	} else {

--- a/agent/functions/userLock/userLock.go
+++ b/agent/functions/userLock/userLock.go
@@ -92,9 +92,9 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 		response.Response = fmt.Sprintf("user %s locked successfully, shutdown in 30 seconds", username)
 		go func() {
 			time.Sleep(30 * time.Second)
-			h.logger.Info(8209, "initiating delayed shutdown after user lock", f)
+			h.logger.Info(8215, "initiating delayed shutdown after user lock", f)
 			if sErr := a.Shutdown(); sErr != nil {
-				h.logger.Error(8210, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
+				h.logger.Error(8216, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
 			}
 		}()
 	} else {

--- a/agent/functions/userLock/userLock.go
+++ b/agent/functions/userLock/userLock.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/global"
@@ -89,14 +88,10 @@ func (h *Handler) Cmd(request schema.AgentRequest) (schema.AgentResponse, error)
 	response.Success = true
 
 	if shutdown {
-		response.Response = fmt.Sprintf("user %s locked successfully, shutdown in 30 seconds", username)
-		go func() {
-			time.Sleep(30 * time.Second)
-			h.logger.Info(8215, "initiating delayed shutdown after user lock", f)
-			if sErr := a.Shutdown(); sErr != nil {
-				h.logger.Error(8216, fmt.Sprintf("delayed shutdown failed: %s", sErr.Error()), f)
-			}
-		}()
+		response.Response = fmt.Sprintf("user %s locked successfully, initiating shutdown", username)
+		response.PreShutdown = true
+		response.ShutdownType = "shutdown"
+		h.logger.Info(8215, "shutdown requested after user lock, syncing before shutdown", f)
 	} else {
 		response.Response = fmt.Sprintf("user %s locked successfully", username)
 	}

--- a/agent/global/cap_linux.go
+++ b/agent/global/cap_linux.go
@@ -6,5 +6,5 @@
 package global
 
 const (
-	HaveServiceAccount = false
+	HaveServiceAccount = true
 )

--- a/agent/global/cap_windows.go
+++ b/agent/global/cap_windows.go
@@ -6,5 +6,5 @@
 package global
 
 const (
-	HaveServiceAccount = false
+	HaveServiceAccount = true
 )

--- a/agent/global/config.go
+++ b/agent/global/config.go
@@ -148,6 +148,8 @@ func (c *AgentConfig) SetServiceCredentials(username, password string) error {
 	// Store encrypted credentials
 	c.serviceCredentialsEncrypted = encrypted
 	c.credentialsPendingSend = true
+	c.AP.Set(ConfigRecoveryInfoPending, true)
+	_ = c.Checkpoint()
 
 	return nil
 }
@@ -222,4 +224,14 @@ func (c *AgentConfig) GetServiceCredentialsForServer() (string, error) {
 // CredentialsPendingSend returns true if credentials need to be sent to server
 func (c *AgentConfig) CredentialsPendingSend() bool {
 	return c.credentialsPendingSend && c.serviceCredentialsEncrypted != ""
+}
+
+// RecoveryInfoPending returns true if recovery info must be re-sent regardless of key hash
+func (c *AgentConfig) RecoveryInfoPending() bool {
+	return c.AP.Get(ConfigRecoveryInfoPending).Bool()
+}
+
+// SetRecoveryInfoPending sets the persistent flag controlling recovery info resend
+func (c *AgentConfig) SetRecoveryInfoPending(pending bool) {
+	c.AP.Set(ConfigRecoveryInfoPending, pending)
 }

--- a/agent/global/config.go
+++ b/agent/global/config.go
@@ -234,4 +234,5 @@ func (c *AgentConfig) RecoveryInfoPending() bool {
 // SetRecoveryInfoPending sets the persistent flag controlling recovery info resend
 func (c *AgentConfig) SetRecoveryInfoPending(pending bool) {
 	c.AP.Set(ConfigRecoveryInfoPending, pending)
+	_ = c.Checkpoint()
 }

--- a/agent/global/defaults.go
+++ b/agent/global/defaults.go
@@ -32,6 +32,7 @@ const (
 	ConfigRecoveryPublicKey     = "recovery_public_key"
 	ConfigRecoveryPublicKeyHash = "recovery_public_key_hash"
 	ConfigRecoveryInfoPending   = "recovery_info_pending"
+	ConfigFriendlyName          = "install_friendly_name"
 )
 
 // setDefaults makes sure the sets exist, sets default values, and constraints
@@ -57,6 +58,7 @@ func setDefaults(c interfaces.Config) (interfaces.Parameters, interfaces.Paramet
 	ap.SetConstraint(ConfigRecoveryPublicKey, 0, 0, "")
 	ap.SetConstraint(ConfigRecoveryPublicKeyHash, 0, 0, "")
 	ap.SetConstraint(ConfigRecoveryInfoPending, 0, 0, false)
+	ap.SetConstraint(ConfigFriendlyName, 0, 0, "")
 
 	// Return the sets
 	return ac, ap

--- a/agent/global/defaults.go
+++ b/agent/global/defaults.go
@@ -31,6 +31,7 @@ const (
 	ConfigAgentECPublicEnc      = "ec_public_enc"
 	ConfigRecoveryPublicKey     = "recovery_public_key"
 	ConfigRecoveryPublicKeyHash = "recovery_public_key_hash"
+	ConfigRecoveryInfoPending   = "recovery_info_pending"
 )
 
 // setDefaults makes sure the sets exist, sets default values, and constraints
@@ -55,6 +56,7 @@ func setDefaults(c interfaces.Config) (interfaces.Parameters, interfaces.Paramet
 	ap.SetConstraint(ConfigAgentECPublicEnc, 0, 0, "")
 	ap.SetConstraint(ConfigRecoveryPublicKey, 0, 0, "")
 	ap.SetConstraint(ConfigRecoveryPublicKeyHash, 0, 0, "")
+	ap.SetConstraint(ConfigRecoveryInfoPending, 0, 0, false)
 
 	// Return the sets
 	return ac, ap

--- a/agent/global/defaults.go
+++ b/agent/global/defaults.go
@@ -14,21 +14,23 @@ import (
 )
 
 const (
-	ConfigPrivate           = "client_private"
-	ConfigRegToken          = "reg_token"
-	ConfigLost              = "config_lost"
-	ConfigAgentLogFile      = "log_file"
-	ConfigAgentDataDir      = "data_dir"
-	ConfigAgentID           = "agent_id"
-	ConfigServerURL         = "server_url"
-	ConfigRefreshToken      = "refresh_token"
-	ConfigCAHash            = "ca_hash"
-	ConfigServerPublicSig   = "server_public_sig"
-	ConfigServerPublicEnc   = "server_public_enc"
-	ConfigAgentECPrivateSig = "ec_private_sig"
-	ConfigAgentECPublicSig  = "ec_public_sig"
-	ConfigAgentECPrivateEnc = "ec_private_enc"
-	ConfigAgentECPublicEnc  = "ec_public_enc"
+	ConfigPrivate               = "client_private"
+	ConfigRegToken              = "reg_token"
+	ConfigLost                  = "config_lost"
+	ConfigAgentLogFile          = "log_file"
+	ConfigAgentDataDir          = "data_dir"
+	ConfigAgentID               = "agent_id"
+	ConfigServerURL             = "server_url"
+	ConfigRefreshToken          = "refresh_token"
+	ConfigCAHash                = "ca_hash"
+	ConfigServerPublicSig       = "server_public_sig"
+	ConfigServerPublicEnc       = "server_public_enc"
+	ConfigAgentECPrivateSig     = "ec_private_sig"
+	ConfigAgentECPublicSig      = "ec_public_sig"
+	ConfigAgentECPrivateEnc     = "ec_private_enc"
+	ConfigAgentECPublicEnc      = "ec_public_enc"
+	ConfigRecoveryPublicKey     = "recovery_public_key"
+	ConfigRecoveryPublicKeyHash = "recovery_public_key_hash"
 )
 
 // setDefaults makes sure the sets exist, sets default values, and constraints
@@ -51,6 +53,8 @@ func setDefaults(c interfaces.Config) (interfaces.Parameters, interfaces.Paramet
 	ap.SetConstraint(ConfigAgentECPublicSig, 0, 0, "")
 	ap.SetConstraint(ConfigAgentECPrivateEnc, 0, 0, "")
 	ap.SetConstraint(ConfigAgentECPublicEnc, 0, 0, "")
+	ap.SetConstraint(ConfigRecoveryPublicKey, 0, 0, "")
+	ap.SetConstraint(ConfigRecoveryPublicKeyHash, 0, 0, "")
 
 	// Return the sets
 	return ac, ap

--- a/agent/install/install.go
+++ b/agent/install/install.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Install struct {
-	config    *global.AgentConfig
-	logger    interfaces.Logger
-	token     string
-	user      string
-	pass      string
-	isUpgrade bool
+	config       *global.AgentConfig
+	logger       interfaces.Logger
+	token        string
+	user         string
+	pass         string
+	friendlyName string
+	isUpgrade    bool
 }
 
 // Option is a functional option for configuring Install
@@ -56,6 +57,13 @@ func WithCredentials(user, pass string) Option {
 func WithToken(token string) Option {
 	return func(i *Install) {
 		i.token = token
+	}
+}
+
+// WithFriendlyName sets the friendly name for the agent (optional, one-time at install)
+func WithFriendlyName(name string) Option {
+	return func(i *Install) {
+		i.friendlyName = name
 	}
 }
 
@@ -137,6 +145,12 @@ func (i *Install) Install() error {
 	err = i.config.Checkpoint()
 	if err != nil {
 		return err
+	}
+
+	// Store friendly name if provided; cleared after successful registration
+	if i.friendlyName != "" {
+		i.config.AP.Set(global.ConfigFriendlyName, i.friendlyName)
+		_ = i.config.Checkpoint()
 	}
 
 	// Call the private function for os specific install

--- a/agent/install/install_linux.go
+++ b/agent/install/install_linux.go
@@ -91,6 +91,12 @@ func (i *Install) installService() error {
 		return err
 	}
 
+	// Create service account before starting the service
+	err = i.ServiceAccount()
+	if err != nil {
+		return fmt.Errorf("failed to create service account: %w", err)
+	}
+
 	// Start the service
 	err = i.startService()
 	if err != nil {

--- a/agent/install/install_windows.go
+++ b/agent/install/install_windows.go
@@ -86,6 +86,12 @@ func (i *Install) installService() error {
 	}
 	fmt.Printf("Binary copied to %s\n", targetPath)
 
+	// Create service account before starting the service
+	err = i.ServiceAccount()
+	if err != nil {
+		return fmt.Errorf("failed to create service account: %w", err)
+	}
+
 	// Install the service
 	m, err := mgr.Connect()
 	if err != nil {

--- a/agent/install/install_windows.go
+++ b/agent/install/install_windows.go
@@ -103,8 +103,8 @@ func (i *Install) installService() error {
 
 	service, err := m.OpenService(global.Name)
 	if err == nil {
+		defer func(s *mgr.Service) { _ = s.Close() }(service)
 		status, qErr := service.Query()
-		_ = service.Close()
 		if qErr != nil {
 			return fmt.Errorf("service %s already exists", global.Name)
 		}
@@ -112,12 +112,7 @@ func (i *Install) installService() error {
 			return fmt.Errorf("service %s is already running", global.Name)
 		}
 		// Service exists but is stopped — start it and return
-		startSvc, openErr := m.OpenService(global.Name)
-		if openErr != nil {
-			return fmt.Errorf("failed to reopen service %s: %w", global.Name, openErr)
-		}
-		defer func(s *mgr.Service) { _ = s.Close() }(startSvc)
-		if startErr := startSvc.Start(); startErr != nil {
+		if startErr := service.Start(); startErr != nil {
 			return fmt.Errorf("failed to start existing service %s: %w", global.Name, startErr)
 		}
 		fmt.Println("Windows service started")

--- a/agent/install/install_windows.go
+++ b/agent/install/install_windows.go
@@ -103,8 +103,25 @@ func (i *Install) installService() error {
 
 	service, err := m.OpenService(global.Name)
 	if err == nil {
+		status, qErr := service.Query()
 		_ = service.Close()
-		return fmt.Errorf("service %s already exists", global.Name)
+		if qErr != nil {
+			return fmt.Errorf("service %s already exists", global.Name)
+		}
+		if status.State == svc.Running {
+			return fmt.Errorf("service %s is already running", global.Name)
+		}
+		// Service exists but is stopped — start it and return
+		startSvc, openErr := m.OpenService(global.Name)
+		if openErr != nil {
+			return fmt.Errorf("failed to reopen service %s: %w", global.Name, openErr)
+		}
+		defer func(s *mgr.Service) { _ = s.Close() }(startSvc)
+		if startErr := startSvc.Start(); startErr != nil {
+			return fmt.Errorf("failed to start existing service %s: %w", global.Name, startErr)
+		}
+		fmt.Println("Windows service started")
+		return nil
 	}
 
 	service, err = m.CreateService(global.Name, targetPath, mgr.Config{

--- a/agent/main.go
+++ b/agent/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/UnifyEM/UnifyEM/agent/communications"
 	"github.com/UnifyEM/UnifyEM/agent/functions"
 	"github.com/UnifyEM/UnifyEM/agent/global"
+	"github.com/UnifyEM/UnifyEM/agent/osActions"
 	"github.com/UnifyEM/UnifyEM/agent/install"
 	"github.com/UnifyEM/UnifyEM/agent/queues"
 	"github.com/UnifyEM/UnifyEM/common"
@@ -570,6 +571,33 @@ func executeRequest(cmd *functions.Command, request schema.AgentRequest) error {
 			fields.NewField("response", response.Response))
 
 		logger.Info(8053, "queued response", logFields)
+
+		// If the handler has requested a pre-shutdown sync, sync now before
+		// performing the OS action. Retry up to 3 times to maximise the chance
+		// of the server receiving the response before the system goes down.
+		if response.PreShutdown {
+			const maxSyncAttempts = 3
+			for i := 0; i < maxSyncAttempts; i++ {
+				communication.Sync()
+				if i < maxSyncAttempts-1 {
+					time.Sleep(2 * time.Second)
+				}
+			}
+
+			a := osActions.New(logger)
+			if response.ShutdownType == "reboot" {
+				logger.Info(8054, "initiating reboot after pre-shutdown sync", logFields)
+				if osErr := a.Reboot(); osErr != nil {
+					logger.Errorf(8056, "reboot failed: %s", osErr.Error())
+				}
+			} else {
+				logger.Info(8055, "initiating shutdown after pre-shutdown sync", logFields)
+				if osErr := a.Shutdown(); osErr != nil {
+					logger.Errorf(8056, "shutdown failed: %s", osErr.Error())
+				}
+			}
+		}
+
 		return nil
 	}
 	return errors.New("no response from command")

--- a/agent/main.go
+++ b/agent/main.go
@@ -6,6 +6,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -468,6 +471,9 @@ func ServiceTasks(interfaces.Logger) {
 		sendServiceCredentials()
 	}
 
+	// Prepare recovery info if enabled and key has changed
+	prepareRecoveryInfo()
+
 	// Check in with the server if it has been more than global.SyncInterval seconds or a shorter
 	// time period applies
 	if syncTime(now - lastSync) {
@@ -673,6 +679,80 @@ func sendServiceCredentials() {
 	// Queue the response for transmission
 	responseQueue.Add(response)
 	logger.Info(8118, "service credentials queued for transmission", nil)
+}
+
+// prepareRecoveryInfo builds, encrypts, and queues recovery info for transmission
+// Returns true if recovery info was prepared, false if skipped
+func prepareRecoveryInfo() bool {
+	// Check if recovery info is enabled in agent config
+	if !conf.AC.Get(schema.ConfigAgentRecoveryInfo).Bool() {
+		return false
+	}
+
+	// Check if recovery public key is available
+	recoveryPublicKey := conf.AP.Get(global.ConfigRecoveryPublicKey).String()
+	if recoveryPublicKey == "" {
+		return false
+	}
+
+	// Only re-send if the recovery public key has changed
+	keyHash := recoveryKeyHash(recoveryPublicKey)
+	storedHash := conf.AP.Get(global.ConfigRecoveryPublicKeyHash).String()
+	if keyHash == storedHash {
+		return false
+	}
+
+	// Build recovery info
+	info := buildRecoveryInfo()
+
+	// Marshal to JSON
+	jsonBytes, err := json.Marshal(info)
+	if err != nil {
+		logger.Errorf(8070, "failed to marshal recovery info: %s", err.Error())
+		return false
+	}
+
+	// Encrypt with recovery public key
+	blob, err := crypto.Encrypt(jsonBytes, recoveryPublicKey)
+	if err != nil {
+		logger.Errorf(8071, "failed to encrypt recovery info: %s", err.Error())
+		return false
+	}
+
+	// Queue for next sync
+	communication.SetPendingRecoveryInfo(blob)
+
+	// Update stored hash so we don't re-send unless key changes
+	conf.AP.Set(global.ConfigRecoveryPublicKeyHash, keyHash)
+	_ = conf.Checkpoint()
+
+	logger.Info(8072, "recovery info prepared for transmission", nil)
+	return true
+}
+
+// buildRecoveryInfo collects OS-neutral recovery information
+func buildRecoveryInfo() schema.RecoveryInfo {
+	hostname, _ := os.Hostname()
+	info := schema.RecoveryInfo{
+		Timestamp: time.Now(),
+		OS:        runtime.GOOS,
+		Hostname:  hostname,
+	}
+
+	// Attempt to get service credentials (succeeds on macOS when configured)
+	username, password, err := conf.GetServiceCredentials()
+	if err == nil {
+		info.ServiceAccount = username
+		info.ServicePassword = password
+	}
+
+	return info
+}
+
+// recoveryKeyHash returns a hex SHA-256 hash of the given key string
+func recoveryKeyHash(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
 }
 
 // simulateService runs the service in the foreground for testing. This is particularly useful on Windows.

--- a/agent/main.go
+++ b/agent/main.go
@@ -124,17 +124,32 @@ func console() int {
 			install.WithToken(os.Args[2]),
 		}
 
-		switch len(os.Args) {
-		case 4:
-			// friendly name only
-			ops = append(ops, install.WithFriendlyName(os.Args[3]))
-		case 5:
-			// credentials only
-			ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
-		case 6:
-			// credentials + friendly name
-			ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
-			ops = append(ops, install.WithFriendlyName(os.Args[5]))
+		if runtime.GOOS == "darwin" {
+			// macOS requires admin credentials to create the service account
+			switch len(os.Args) {
+			case 4:
+				fmt.Println("Usage: install <token> [<admin-username> <admin-password> [<friendly-name>]]")
+				return 1
+			case 5:
+				// credentials only
+				ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
+			case 6:
+				// credentials + friendly name
+				ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
+				ops = append(ops, install.WithFriendlyName(os.Args[5]))
+			}
+		} else {
+			// Linux/Windows: no credentials required
+			switch len(os.Args) {
+			case 4:
+				// friendly name only
+				ops = append(ops, install.WithFriendlyName(os.Args[3]))
+			default:
+				if len(os.Args) > 4 {
+					fmt.Println("Usage: install <token> [<friendly-name>]")
+					return 1
+				}
+			}
 		}
 
 		// Instantiate installer

--- a/agent/main.go
+++ b/agent/main.go
@@ -590,6 +590,9 @@ func executeRequest(cmd *functions.Command, request schema.AgentRequest) error {
 				}
 			}
 
+			// Allow time for the final sync to complete transmission
+			time.Sleep(5 * time.Second)
+
 			a := osActions.New(logger)
 			if response.ShutdownType == "reboot" {
 				logger.Info(8054, "initiating reboot after pre-shutdown sync", logFields)

--- a/agent/main.go
+++ b/agent/main.go
@@ -698,10 +698,10 @@ func prepareRecoveryInfo() bool {
 		return false
 	}
 
-	// Only re-send if the recovery public key has changed
+	// Re-send if recovery public key has changed OR a resend is pending (e.g. credentials updated)
 	keyHash := recoveryKeyHash(recoveryPublicKey)
 	storedHash := conf.AP.Get(global.ConfigRecoveryPublicKeyHash).String()
-	if keyHash == storedHash {
+	if keyHash == storedHash && !conf.RecoveryInfoPending() {
 		return false
 	}
 
@@ -725,8 +725,9 @@ func prepareRecoveryInfo() bool {
 	// Queue for next sync
 	communication.SetPendingRecoveryInfo(blob)
 
-	// Update stored hash so we don't re-send unless key changes
+	// Update stored hash and clear pending flag so we don't re-send unless key changes or flag is set again
 	conf.AP.Set(global.ConfigRecoveryPublicKeyHash, keyHash)
+	conf.SetRecoveryInfoPending(false)
 	_ = conf.Checkpoint()
 
 	logger.Info(8072, "recovery info prepared for transmission", nil)

--- a/agent/main.go
+++ b/agent/main.go
@@ -126,13 +126,13 @@ func console() int {
 
 		switch len(os.Args) {
 		case 4:
-			// friendly name only (non-macOS platforms)
+			// friendly name only
 			ops = append(ops, install.WithFriendlyName(os.Args[3]))
 		case 5:
-			// credentials only (macOS)
+			// credentials only
 			ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
 		case 6:
-			// credentials + friendly name (macOS)
+			// credentials + friendly name
 			ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
 			ops = append(ops, install.WithFriendlyName(os.Args[5]))
 		}

--- a/agent/main.go
+++ b/agent/main.go
@@ -742,6 +742,8 @@ func buildRecoveryInfo() schema.RecoveryInfo {
 		Hostname:  hostname,
 	}
 
+	info.BitLockerInfo = getBitLockerInfo()
+
 	// Attempt to get service credentials (succeeds on macOS when configured)
 	username, password, err := conf.GetServiceCredentials()
 	if err == nil {

--- a/agent/main.go
+++ b/agent/main.go
@@ -125,11 +125,12 @@ func console() int {
 		}
 
 		if runtime.GOOS == "darwin" {
-			// macOS requires admin credentials to create the service account
+			// macOS: credentials are optional on the command line; if omitted the
+			// installer will prompt interactively. Friendly name is always optional.
 			switch len(os.Args) {
 			case 4:
-				fmt.Println("Usage: install <token> [<admin-username> <admin-password> [<friendly-name>]]")
-				return 1
+				// friendly name only; credentials will be prompted
+				ops = append(ops, install.WithFriendlyName(os.Args[3]))
 			case 5:
 				// credentials only
 				ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
@@ -137,9 +138,14 @@ func console() int {
 				// credentials + friendly name
 				ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
 				ops = append(ops, install.WithFriendlyName(os.Args[5]))
+			default:
+				if len(os.Args) > 6 {
+					fmt.Println("Usage: install <token> [<admin-username> <admin-password> [<friendly-name>]]")
+					return 1
+				}
 			}
 		} else {
-			// Linux/Windows: no credentials required
+			// Linux/Windows: no credentials required or accepted
 			switch len(os.Args) {
 			case 4:
 				// friendly name only

--- a/agent/main.go
+++ b/agent/main.go
@@ -611,7 +611,7 @@ func executeRequest(cmd *functions.Command, request schema.AgentRequest) error {
 			} else {
 				logger.Info(8055, "initiating shutdown after pre-shutdown sync", logFields)
 				if osErr := a.Shutdown(); osErr != nil {
-					logger.Errorf(8056, "shutdown failed: %s", osErr.Error())
+					logger.Errorf(8073, "shutdown failed: %s", osErr.Error())
 				}
 			}
 		}

--- a/agent/main.go
+++ b/agent/main.go
@@ -124,8 +124,17 @@ func console() int {
 			install.WithToken(os.Args[2]),
 		}
 
-		if len(os.Args) >= 5 {
+		switch len(os.Args) {
+		case 4:
+			// friendly name only (non-macOS platforms)
+			ops = append(ops, install.WithFriendlyName(os.Args[3]))
+		case 5:
+			// credentials only (macOS)
 			ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
+		case 6:
+			// credentials + friendly name (macOS)
+			ops = append(ops, install.WithCredentials(os.Args[3], os.Args[4]))
+			ops = append(ops, install.WithFriendlyName(os.Args[5]))
 		}
 
 		// Instantiate installer
@@ -335,9 +344,9 @@ func usage() {
 	fmt.Printf("  check\n")
 
 	if runtime.GOOS == "darwin" {
-		fmt.Printf("  install <token> <admin-username> <admin-password>\n")
+		fmt.Printf("  install <token> [<admin-username> <admin-password> [<friendly-name>]]\n")
 	} else {
-		fmt.Printf("  install <token>\n")
+		fmt.Printf("  install <token> [<friendly-name>]\n")
 	}
 
 	fmt.Printf("  rekey <token>\n")

--- a/agent/main_darwin.go
+++ b/agent/main_darwin.go
@@ -122,3 +122,7 @@ func getCurrentUsername() string {
 	}
 	return u.Username
 }
+
+func getBitLockerInfo() string {
+	return ""
+}

--- a/agent/main_linux.go
+++ b/agent/main_linux.go
@@ -31,3 +31,7 @@ func cleanupUserDataListener(log interfaces.Logger) {
 func getUserDataSource() *userdata.UserDataListener {
 	return nil
 }
+
+func getBitLockerInfo() string {
+	return ""
+}

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -8,6 +8,9 @@
 package main
 
 import (
+	"os/exec"
+	"strings"
+
 	"github.com/UnifyEM/UnifyEM/agent/userdata"
 	"github.com/UnifyEM/UnifyEM/common/interfaces"
 )
@@ -30,4 +33,12 @@ func cleanupUserDataListener(_ interfaces.Logger) {
 // getUserDataSource returns nil on Windows
 func getUserDataSource() *userdata.UserDataListener {
 	return nil
+}
+
+func getBitLockerInfo() string {
+	out, err := exec.Command("manage-bde", "-protectors", "-get", "C:").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -38,7 +38,7 @@ func getUserDataSource() *userdata.UserDataListener {
 }
 
 func getBitLockerInfo() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "manage-bde", "-protectors", "-get", "C:").CombinedOutput()
 	if err != nil {

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -8,8 +8,10 @@
 package main
 
 import (
+	"context"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/UnifyEM/UnifyEM/agent/userdata"
 	"github.com/UnifyEM/UnifyEM/common/interfaces"
@@ -36,8 +38,13 @@ func getUserDataSource() *userdata.UserDataListener {
 }
 
 func getBitLockerInfo() string {
-	out, err := exec.Command("manage-bde", "-protectors", "-get", "C:").CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "manage-bde", "-protectors", "-get", "C:").CombinedOutput()
 	if err != nil {
+		if logger != nil {
+			logger.Warningf(8608, "failed to retrieve BitLocker info: %s", err.Error())
+		}
 		return ""
 	}
 	return strings.TrimSpace(string(out))

--- a/agent/osActions/users_windows.go
+++ b/agent/osActions/users_windows.go
@@ -157,7 +157,14 @@ func (a *Actions) setPassword(userInfo UserInfo) error {
 		return fmt.Errorf("username and password are required")
 	}
 
-	_, err := a.runner.Combined("net", "user", userInfo.Username, userInfo.Password)
+	escapedPW := escapePowerShellString(userInfo.Password)
+	_, err := a.runner.Combined(
+		"powershell", "-Command",
+		fmt.Sprintf(
+			"Set-LocalUser -Name '%s' -Password (ConvertTo-SecureString '%s' -AsPlainText -Force)",
+			userInfo.Username, escapedPW,
+		),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to set password for user %s: %w", userInfo.Username, err)
 	}
@@ -172,20 +179,26 @@ func (a *Actions) addUser(userInfo UserInfo) error {
 	}
 
 	// Create the user and set the password
-	_, err := a.runner.Combined("net", "user", userInfo.Username, userInfo.Password, "/ADD")
+	escapedPW := escapePowerShellString(userInfo.Password)
+	_, err := a.runner.Combined(
+		"powershell", "-Command",
+		fmt.Sprintf(
+			"New-LocalUser -Name '%s' -Password (ConvertTo-SecureString '%s' -AsPlainText -Force) -PasswordNeverExpires -AccountNeverExpires",
+			userInfo.Username, escapedPW,
+		),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create user %s: %w", userInfo.Username, err)
 	}
 
 	// Add the user's password to allow boot drive bitlocker access
-	// Escape PowerShell special characters: single quotes, backticks, dollar signs
-	escapedPW := escapePowerShellString(userInfo.Password)
+	escapedPWBL := escapePowerShellString(userInfo.Password)
 	_, err = a.runner.Combined(
 		"powershell",
 		"-Command",
 		fmt.Sprintf(
 			"Add-BitLockerKeyProtector -MountPoint 'C:' -PasswordProtector -Password (ConvertTo-SecureString '%s' -AsPlainText -Force)",
-			escapedPW,
+			escapedPWBL,
 		),
 	)
 	if err != nil {
@@ -360,8 +373,15 @@ func (a *Actions) refreshServiceAccount(userInfo UserInfo) (string, error) {
 	// Generate a new random password
 	newPassword := crypto.RandomPassword()
 
-	// Set the new password using net user (runs as SYSTEM, no old password needed)
-	_, err = a.runner.Combined("net", "user", userInfo.Username, newPassword)
+	// Set the new password using PowerShell (no interactive prompt, no 14-char limit)
+	escapedPW := escapePowerShellString(newPassword)
+	_, err = a.runner.Combined(
+		"powershell", "-Command",
+		fmt.Sprintf(
+			"Set-LocalUser -Name '%s' -Password (ConvertTo-SecureString '%s' -AsPlainText -Force)",
+			userInfo.Username, escapedPW,
+		),
+	)
 	if err != nil {
 		return "", fmt.Errorf("failed to change password for user %s: %w", userInfo.Username, err)
 	}
@@ -374,12 +394,12 @@ func (a *Actions) refreshServiceAccount(userInfo UserInfo) (string, error) {
 	}
 
 	// Add new password protector
-	escapedPW := escapePowerShellString(newPassword)
+	escapedPWBL := escapePowerShellString(newPassword)
 	_, addErr := a.runner.Combined(
 		"powershell", "-Command",
 		fmt.Sprintf(
 			"Add-BitLockerKeyProtector -MountPoint 'C:' -PasswordProtector -Password (ConvertTo-SecureString '%s' -AsPlainText -Force)",
-			escapedPW,
+			escapedPWBL,
 		),
 	)
 	if addErr != nil {

--- a/agent/osActions/users_windows.go
+++ b/agent/osActions/users_windows.go
@@ -366,6 +366,31 @@ func (a *Actions) refreshServiceAccount(userInfo UserInfo) (string, error) {
 		return "", fmt.Errorf("failed to change password for user %s: %w", userInfo.Username, err)
 	}
 
+	// Remove old password protectors
+	_, delErr := a.runner.Combined("manage-bde", "-protectors", "-delete", "C:", "-Type", "Password")
+	if delErr != nil {
+		a.logger.Warningf(8605, "failed to remove old BitLocker password protectors: %s", delErr.Error())
+		// Continue anyway
+	}
+
+	// Add new password protector
+	escapedPW := escapePowerShellString(newPassword)
+	_, addErr := a.runner.Combined(
+		"powershell", "-Command",
+		fmt.Sprintf(
+			"Add-BitLockerKeyProtector -MountPoint 'C:' -PasswordProtector -Password (ConvertTo-SecureString '%s' -AsPlainText -Force)",
+			escapedPW,
+		),
+	)
+	if addErr != nil {
+		if strings.Contains(addErr.Error(), "BitLocker is not enabled") {
+			a.logger.Warningf(8606, "BitLocker is not enabled, skipping protector update for %s", userInfo.Username)
+		} else {
+			a.logger.Warningf(8607, "failed to update BitLocker password protector: %s", addErr.Error())
+		}
+		// Continue anyway
+	}
+
 	return newPassword, nil
 }
 

--- a/cli/certstore/certstore.go
+++ b/cli/certstore/certstore.go
@@ -1,0 +1,101 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package certstore
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const certFile = ".uemcert"
+
+// Fingerprint computes the SHA-256 fingerprint of a DER-encoded certificate.
+func Fingerprint(cert *x509.Certificate) string {
+	hash := sha256.Sum256(cert.Raw)
+	return fmt.Sprintf("%X", hash)
+}
+
+// FormatCertDetails returns a human-readable summary of a certificate.
+func FormatCertDetails(cert *x509.Certificate) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  Subject:     %s\n", cert.Subject))
+	b.WriteString(fmt.Sprintf("  Issuer:      %s\n", cert.Issuer))
+	b.WriteString(fmt.Sprintf("  Fingerprint: %s\n", Fingerprint(cert)))
+	b.WriteString(fmt.Sprintf("  Not Before:  %s\n", cert.NotBefore.Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("  Not After:   %s\n", cert.NotAfter.Format(time.RFC3339)))
+	if len(cert.DNSNames) > 0 {
+		b.WriteString(fmt.Sprintf("  DNS Names:   %s\n", strings.Join(cert.DNSNames, ", ")))
+	}
+	return b.String()
+}
+
+// certFilePath returns the full path to ~/.uemcert.
+func certFilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine home directory: %w", err)
+	}
+	return filepath.Join(homeDir, certFile), nil
+}
+
+// IsTrusted checks whether the given host and fingerprint are stored in ~/.uemcert.
+func IsTrusted(host, fingerprint string) (bool, error) {
+	path, err := certFilePath()
+	if err != nil {
+		return false, err
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("unable to open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[0] == host && parts[1] == fingerprint {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
+}
+
+// Store appends a host and fingerprint entry to ~/.uemcert.
+func Store(host, fingerprint string) error {
+	path, err := certFilePath()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to open %s for writing: %w", path, err)
+	}
+	defer f.Close()
+
+	_, err = fmt.Fprintf(f, "%s %s\n", host, fingerprint)
+	if err != nil {
+		return fmt.Errorf("unable to write to %s: %w", path, err)
+	}
+	return nil
+}

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -14,6 +14,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -76,7 +77,7 @@ func TestFormatCertDetails(t *testing.T) {
 
 	// Check that key fields are present
 	for _, expected := range []string{"Subject:", "Issuer:", "Fingerprint:", "Not Before:", "Not After:", "DNS Names:"} {
-		if !containsString(details, expected) {
+		if !strings.Contains(details, expected) {
 			t.Errorf("expected %q in cert details", expected)
 		}
 	}
@@ -186,15 +187,3 @@ func TestStoreMultiple(t *testing.T) {
 	}
 }
 
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -1,0 +1,200 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package certstore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateTestCert creates a self-signed certificate for testing.
+func generateTestCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+			CommonName:   "test.example.com",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+		DNSNames:  []string{"test.example.com", "localhost"},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return cert
+}
+
+func TestFingerprint(t *testing.T) {
+	cert := generateTestCert(t)
+	fp := Fingerprint(cert)
+	if fp == "" {
+		t.Fatal("fingerprint should not be empty")
+	}
+	if len(fp) != 64 {
+		t.Fatalf("expected 64 hex characters, got %d", len(fp))
+	}
+
+	// Same cert should produce same fingerprint
+	fp2 := Fingerprint(cert)
+	if fp != fp2 {
+		t.Fatal("fingerprint should be deterministic")
+	}
+}
+
+func TestFormatCertDetails(t *testing.T) {
+	cert := generateTestCert(t)
+	details := FormatCertDetails(cert)
+	if details == "" {
+		t.Fatal("cert details should not be empty")
+	}
+
+	// Check that key fields are present
+	for _, expected := range []string{"Subject:", "Issuer:", "Fingerprint:", "Not Before:", "Not After:", "DNS Names:"} {
+		if !containsString(details, expected) {
+			t.Errorf("expected %q in cert details", expected)
+		}
+	}
+}
+
+func TestStoreAndIsTrusted(t *testing.T) {
+	// Use a temp directory as home
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	host := "server.example.com:443"
+	fp := "AABBCCDD0011223344556677889900AABBCCDD0011223344556677889900AABB"
+
+	// Should not be trusted initially
+	trusted, err := IsTrusted(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("should not be trusted before storing")
+	}
+
+	// Store it
+	err = Store(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error storing: %v", err)
+	}
+
+	// Should now be trusted
+	trusted, err = IsTrusted(host, fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !trusted {
+		t.Fatal("should be trusted after storing")
+	}
+
+	// Different host should not be trusted
+	trusted, err = IsTrusted("other.example.com:443", fp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("different host should not be trusted")
+	}
+
+	// Different fingerprint should not be trusted
+	trusted, err = IsTrusted(host, "DIFFERENT_FINGERPRINT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("different fingerprint should not be trusted")
+	}
+
+	// Verify file permissions
+	path := filepath.Join(tmpDir, certFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("unable to stat cert file: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected file permissions 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestIsTrustedMissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	trusted, err := IsTrusted("host:443", "FP")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if trusted {
+		t.Fatal("should not be trusted when file does not exist")
+	}
+}
+
+func TestStoreMultiple(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	entries := []struct {
+		host string
+		fp   string
+	}{
+		{"host1:443", "FP1"},
+		{"host2:8443", "FP2"},
+		{"host3:443", "FP3"},
+	}
+
+	for _, e := range entries {
+		if err := Store(e.host, e.fp); err != nil {
+			t.Fatalf("unexpected error storing %s: %v", e.host, err)
+		}
+	}
+
+	for _, e := range entries {
+		trusted, err := IsTrusted(e.host, e.fp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !trusted {
+			t.Fatalf("%s should be trusted", e.host)
+		}
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cli/certstore/certstore_test.go
+++ b/cli/certstore/certstore_test.go
@@ -186,4 +186,3 @@ func TestStoreMultiple(t *testing.T) {
 		}
 	}
 }
-

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -48,7 +49,7 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 	if err != nil {
 		// Check if this is an untrusted certificate error
 		var certErr *UntrustedCertError
-		if matchUntrustedCertError(err, &certErr) {
+		if errors.As(err, &certErr) {
 			// Prompt the user to accept the certificate
 			accepted, promptErr := promptUserForCert(certErr.Cert, certErr.Host)
 			if promptErr != nil {
@@ -182,45 +183,6 @@ func promptUserForCert(cert *x509.Certificate, host string) (bool, error) {
 
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	return answer == "yes" || answer == "y", nil
-}
-
-// matchUntrustedCertError unwraps err to find an *UntrustedCertError.
-// Returns true if found, setting target to the matched error.
-func matchUntrustedCertError(err error, target **UntrustedCertError) bool {
-	if err == nil {
-		return false
-	}
-	// The error is typically wrapped by net/http and tls layers, so we
-	// need to walk the chain. errors.As won't always work because
-	// some wrapping in net/url uses opaque string formatting. We do a
-	// recursive unwrap plus a type-switch approach.
-	type unwrapper interface {
-		Unwrap() error
-	}
-	type unwrapperSlice interface {
-		Unwrap() []error
-	}
-
-	switch e := err.(type) {
-	case *UntrustedCertError:
-		*target = e
-		return true
-	case unwrapper:
-		return matchUntrustedCertError(e.Unwrap(), target)
-	case unwrapperSlice:
-		for _, inner := range e.Unwrap() {
-			if matchUntrustedCertError(inner, target) {
-				return true
-			}
-		}
-	}
-
-	// Last resort: check if it's a *url.Error wrapping our error
-	if urlErr, ok := err.(*url.Error); ok {
-		return matchUntrustedCertError(urlErr.Err, target)
-	}
-
-	return false
 }
 
 // hostFromURL extracts the host:port from a URL string.

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -6,22 +6,77 @@
 package communications
 
 import (
+	"bufio"
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 
+	"github.com/UnifyEM/UnifyEM/cli/certstore"
 	"github.com/UnifyEM/UnifyEM/cli/global"
 )
+
+// UntrustedCertError is returned when a server presents a certificate
+// that is neither trusted by the system roots nor stored in ~/.uemcert.
+type UntrustedCertError struct {
+	Cert *x509.Certificate
+	Host string
+}
+
+func (e *UntrustedCertError) Error() string {
+	return fmt.Sprintf("untrusted certificate from %s", e.Host)
+}
 
 // sendRequest is a lower level function that sends HTTP requests
 func (c *Communications) sendRequest(method, endpoint string, payload []byte) (int, []byte, error) {
 
 	// Build the request URL
-	url := fmt.Sprintf("%s%s", global.ServerURL, endpoint)
+	reqURL := fmt.Sprintf("%s%s", global.ServerURL, endpoint)
 
-	// Create a new HTTP request
-	httpReq, err := http.NewRequest(method, url, bytes.NewBuffer(payload))
+	// Extract host:port for certificate operations
+	host := hostFromURL(reqURL)
+
+	// Build the HTTP client with TLS certificate verification
+	client := c.buildHTTPClient(host)
+
+	code, body, err := c.doRequest(client, method, reqURL, payload)
+	if err != nil {
+		// Check if this is an untrusted certificate error
+		var certErr *UntrustedCertError
+		if matchUntrustedCertError(err, &certErr) {
+			// Prompt the user to accept the certificate
+			accepted, promptErr := promptUserForCert(certErr.Cert, certErr.Host)
+			if promptErr != nil {
+				return 0, nil, fmt.Errorf("failed to prompt for certificate acceptance: %w", promptErr)
+			}
+			if !accepted {
+				return 0, nil, fmt.Errorf("certificate rejected by user")
+			}
+
+			// Store the accepted fingerprint
+			fp := certstore.Fingerprint(certErr.Cert)
+			if storeErr := certstore.Store(host, fp); storeErr != nil {
+				return 0, nil, fmt.Errorf("failed to store certificate: %w", storeErr)
+			}
+
+			// Retry with the now-trusted certificate
+			client = c.buildHTTPClient(host)
+			return c.doRequest(client, method, reqURL, payload)
+		}
+		return 0, nil, err
+	}
+	return code, body, nil
+}
+
+// doRequest executes an HTTP request and returns status code, body, and error.
+func (c *Communications) doRequest(client *http.Client, method, reqURL string, payload []byte) (int, []byte, error) {
+
+	httpReq, err := http.NewRequest(method, reqURL, bytes.NewBuffer(payload))
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -36,8 +91,6 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
 
-	// Send the request
-	client := &http.Client{}
 	resp, err := client.Do(httpReq)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to send HTTP request: %w", err)
@@ -54,4 +107,134 @@ func (c *Communications) sendRequest(method, endpoint string, payload []byte) (i
 	}
 
 	return resp.StatusCode, responseBody.Bytes(), nil
+}
+
+// buildHTTPClient creates an http.Client with custom TLS verification
+// that trusts certificates whose fingerprints are stored in ~/.uemcert.
+func (c *Communications) buildHTTPClient(host string) *http.Client {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("server presented no certificates")
+			}
+
+			cert, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return fmt.Errorf("failed to parse server certificate: %w", err)
+			}
+
+			// First, try standard system root verification
+			roots, err := x509.SystemCertPool()
+			if err == nil && roots != nil {
+				opts := x509.VerifyOptions{
+					Roots:         roots,
+					Intermediates: x509.NewCertPool(),
+				}
+				// Add intermediate certs if present
+				for _, rawCert := range rawCerts[1:] {
+					intermediateCert, parseErr := x509.ParseCertificate(rawCert)
+					if parseErr == nil {
+						opts.Intermediates.AddCert(intermediateCert)
+					}
+				}
+				if _, verifyErr := cert.Verify(opts); verifyErr == nil {
+					return nil
+				}
+			}
+
+			// System verification failed — check the fingerprint store
+			fp := certstore.Fingerprint(cert)
+			trusted, err := certstore.IsTrusted(host, fp)
+			if err != nil {
+				return fmt.Errorf("failed to check certificate store: %w", err)
+			}
+			if trusted {
+				return nil
+			}
+
+			// Not trusted by any means — return a typed error for prompting
+			return &UntrustedCertError{Cert: cert, Host: host}
+		},
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// promptUserForCert displays certificate details and asks the user to accept or reject.
+func promptUserForCert(cert *x509.Certificate, host string) (bool, error) {
+	fmt.Printf("\nWARNING: The server at %s presented an untrusted certificate:\n\n", host)
+	fmt.Print(certstore.FormatCertDetails(cert))
+	fmt.Print("\nDo you want to trust this certificate? (yes/no): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "yes" || answer == "y", nil
+}
+
+// matchUntrustedCertError unwraps err to find an *UntrustedCertError.
+// Returns true if found, setting target to the matched error.
+func matchUntrustedCertError(err error, target **UntrustedCertError) bool {
+	if err == nil {
+		return false
+	}
+	// The error is typically wrapped by net/http and tls layers, so we
+	// need to walk the chain. errors.As won't always work because
+	// some wrapping in net/url uses opaque string formatting. We do a
+	// recursive unwrap plus a type-switch approach.
+	type unwrapper interface {
+		Unwrap() error
+	}
+	type unwrapperSlice interface {
+		Unwrap() []error
+	}
+
+	switch e := err.(type) {
+	case *UntrustedCertError:
+		*target = e
+		return true
+	case unwrapper:
+		return matchUntrustedCertError(e.Unwrap(), target)
+	case unwrapperSlice:
+		for _, inner := range e.Unwrap() {
+			if matchUntrustedCertError(inner, target) {
+				return true
+			}
+		}
+	}
+
+	// Last resort: check if it's a *url.Error wrapping our error
+	if urlErr, ok := err.(*url.Error); ok {
+		return matchUntrustedCertError(urlErr.Err, target)
+	}
+
+	return false
+}
+
+// hostFromURL extracts the host:port from a URL string.
+// If no port is specified, defaults based on scheme.
+func hostFromURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	host := parsed.Hostname()
+	port := parsed.Port()
+	if port == "" {
+		if parsed.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return host + ":" + port
 }

--- a/cli/communications/send.go
+++ b/cli/communications/send.go
@@ -127,7 +127,10 @@ func (c *Communications) buildHTTPClient(host string) *http.Client {
 			// First, try standard system root verification
 			roots, err := x509.SystemCertPool()
 			if err == nil && roots != nil {
+				// Extract hostname without port for DNSName verification
+				dnsName, _, _ := strings.Cut(host, ":")
 				opts := x509.VerifyOptions{
+					DNSName:       dnsName,
 					Roots:         roots,
 					Intermediates: x509.NewCertPool(),
 				}

--- a/cli/functions/agent/agent.go
+++ b/cli/functions/agent/agent.go
@@ -190,16 +190,19 @@ func agentStatus(_ []string, _ *util.NVPairs) error {
 		return fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
+
 	if len(resp.Data.Agents) == 0 {
 		fmt.Printf("No agents found\n")
 	} else {
+		fmt.Println()
+		// No column headers by design — output is intended for scripting and parsing
 		for _, agent := range resp.Data.Agents {
 			days := int(time.Since(agent.LastSeen).Hours() / 24)
 			fmt.Printf("%-30s %-36s %3d %s-%03d\n", agent.FriendlyName, agent.AgentID, days, agent.Version, agent.Build)
 		}
 	}
 
-	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
 	return nil
 }
 

--- a/cli/functions/agent/agent.go
+++ b/cli/functions/agent/agent.go
@@ -195,7 +195,7 @@ func agentStatus(_ []string, _ *util.NVPairs) error {
 	} else {
 		for _, agent := range resp.Data.Agents {
 			days := int(time.Since(agent.LastSeen).Hours() / 24)
-			fmt.Printf("%-30s %-36s %d\n", agent.FriendlyName, agent.AgentID, days)
+			fmt.Printf("%-30s %-36s %3d %s-%03d\n", agent.FriendlyName, agent.AgentID, days, agent.Version, agent.Build)
 		}
 	}
 

--- a/cli/functions/agent/agent.go
+++ b/cli/functions/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -41,6 +42,15 @@ func Register() *cobra.Command {
 		Long:  "request a list of agents",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return agentList(args, util.NewNVPairs(args))
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "list agent check-in status",
+		Long:  "list all agents with days since last check-in (0 = today)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return agentStatus(args, util.NewNVPairs(args))
 		},
 	})
 
@@ -165,6 +175,31 @@ func Register() *cobra.Command {
 func agentList(_ []string, _ *util.NVPairs) error {
 	c := communications.New(login.Login())
 	display.ErrorWrapper(display.AnyResp(c.Get(schema.EndpointAgent)))
+	return nil
+}
+
+func agentStatus(_ []string, _ *util.NVPairs) error {
+	c := communications.New(login.Login())
+	statusCode, data, err := c.Get(schema.EndpointAgent)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve agent list: %w", err)
+	}
+
+	var resp schema.APIAgentInfoResponse
+	if err = json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(resp.Data.Agents) == 0 {
+		fmt.Printf("No agents found\n")
+	} else {
+		for _, agent := range resp.Data.Agents {
+			days := int(time.Since(agent.LastSeen).Hours() / 24)
+			fmt.Printf("%-30s %-36s %d\n", agent.FriendlyName, agent.AgentID, days)
+		}
+	}
+
+	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
 	return nil
 }
 

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -119,6 +119,19 @@ func recoveryKeygen(args []string, _ *util.NVPairs) error {
 	return nil
 }
 
+func fetchRecoveryInfo(agentID string) (schema.APIRecoveryResponse, int, error) {
+	c := communications.New(login.Login())
+	statusCode, data, err := c.Get(schema.EndpointAgent + "/" + agentID + "/recovery")
+	if err != nil {
+		return schema.APIRecoveryResponse{}, statusCode, fmt.Errorf("failed to retrieve recovery info: %w", err)
+	}
+	var resp schema.APIRecoveryResponse
+	if err = json.Unmarshal(data, &resp); err != nil {
+		return schema.APIRecoveryResponse{}, statusCode, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return resp, statusCode, nil
+}
+
 func recoveryGet(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
 		return errors.New("agent ID is required")
@@ -130,19 +143,12 @@ func recoveryGet(args []string, _ *util.NVPairs) error {
 		keyPath = args[1]
 	}
 
-	// Fetch encrypted blob from server
-	c := communications.New(login.Login())
-	statusCode, data, err := c.Get(schema.EndpointAgent + "/" + agentID + "/recovery")
+	resp, statusCode, err := fetchRecoveryInfo(agentID)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve recovery info: %w", err)
+		return err
 	}
 
 	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
-
-	var resp schema.APIRecoveryResponse
-	if err = json.Unmarshal(data, &resp); err != nil {
-		return fmt.Errorf("failed to unmarshal response: %w", err)
-	}
 
 	if resp.RecoveryInfo == "" {
 		global.Pretty(resp)
@@ -191,18 +197,12 @@ func recoveryCheck(args []string, _ *util.NVPairs) error {
 
 	agentID := args[0]
 
-	c := communications.New(login.Login())
-	statusCode, data, err := c.Get(schema.EndpointAgent + "/" + agentID + "/recovery")
+	resp, statusCode, err := fetchRecoveryInfo(agentID)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve recovery info: %w", err)
+		return err
 	}
 
 	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
-
-	var resp schema.APIRecoveryResponse
-	if err = json.Unmarshal(data, &resp); err != nil {
-		return fmt.Errorf("failed to unmarshal response: %w", err)
-	}
 
 	if resp.RecoveryInfo != "" {
 		fmt.Printf("Recovery info available\n")

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -1,0 +1,175 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package recovery
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/UnifyEM/UnifyEM/cli/communications"
+	"github.com/UnifyEM/UnifyEM/cli/display"
+	"github.com/UnifyEM/UnifyEM/cli/global"
+	"github.com/UnifyEM/UnifyEM/cli/login"
+	"github.com/UnifyEM/UnifyEM/cli/util"
+	"github.com/UnifyEM/UnifyEM/common/crypto"
+	"github.com/UnifyEM/UnifyEM/common/schema"
+)
+
+const defaultKeyFile = "recovery_key.pem"
+
+func Register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recovery",
+		Short: "recovery key functions",
+		Long:  "manage recovery keys and retrieve agent recovery information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("A subcommand is required\n")
+			}
+			return fmt.Errorf("Unknown subcommand: %s\n", args[0])
+		},
+	}
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "keygen [output_path]",
+		Short: "generate recovery keypair",
+		Long:  "generate a recovery keypair, save the private key to a file, and upload the public key to the server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return recoveryKeygen(args, util.NewNVPairs(args))
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "get <agent_id> [key_path]",
+		Short: "get agent recovery info",
+		Long:  "retrieve and decrypt recovery information for the specified agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return recoveryGet(args, util.NewNVPairs(args))
+		},
+	})
+
+	return cmd
+}
+
+func recoveryKeygen(args []string, _ *util.NVPairs) error {
+	outputPath := defaultKeyFile
+	if len(args) > 0 {
+		outputPath = args[0]
+	}
+
+	// Generate keypair
+	privateKey, publicKey, err := crypto.GenerateSingleKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate keypair: %w", err)
+	}
+
+	// Prompt for optional passphrase
+	passphrase, err := promptPassphrase("Enter passphrase (leave empty for no encryption): ")
+	if err != nil {
+		return fmt.Errorf("failed to read passphrase: %w", err)
+	}
+
+	if passphrase != "" {
+		confirm, err := promptPassphrase("Confirm passphrase: ")
+		if err != nil {
+			return fmt.Errorf("failed to read passphrase confirmation: %w", err)
+		}
+		if passphrase != confirm {
+			return errors.New("passphrases do not match")
+		}
+	}
+
+	// Save private key to PEM file
+	err = crypto.SavePrivateKeyPEM(privateKey, outputPath, passphrase)
+	if err != nil {
+		return fmt.Errorf("failed to save private key: %w", err)
+	}
+	fmt.Printf("Private key saved to: %s\n", outputPath)
+
+	// Upload public key to server
+	c := communications.New(login.Login())
+	keyReq := schema.RecoveryKeyRequest{PublicKey: publicKey}
+	display.ErrorWrapper(display.GenericResp(c.Post(schema.EndpointRecovery+"/key", keyReq)))
+	return nil
+}
+
+func recoveryGet(args []string, _ *util.NVPairs) error {
+	if len(args) == 0 {
+		return errors.New("agent ID is required\n")
+	}
+
+	agentID := args[0]
+	keyPath := defaultKeyFile
+	if len(args) > 1 {
+		keyPath = args[1]
+	}
+
+	// Fetch encrypted blob from server
+	c := communications.New(login.Login())
+	statusCode, data, err := c.Get(schema.EndpointAgent + "/" + agentID + "/recovery")
+	if err != nil {
+		return fmt.Errorf("failed to retrieve recovery info: %w", err)
+	}
+
+	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
+
+	var resp schema.APIRecoveryResponse
+	if err = json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if resp.RecoveryInfo == "" {
+		global.Pretty(resp)
+		return nil
+	}
+
+	// Try to load the private key without passphrase first
+	privateKey, err := crypto.LoadPrivateKeyPEM(keyPath, "")
+	if err != nil {
+		// Key may be encrypted — prompt for passphrase
+		passphrase, pErr := promptPassphrase("Enter passphrase for private key: ")
+		if pErr != nil {
+			return fmt.Errorf("failed to read passphrase: %w", pErr)
+		}
+		privateKey, err = crypto.LoadPrivateKeyPEM(keyPath, passphrase)
+		if err != nil {
+			return fmt.Errorf("failed to load private key: %w", err)
+		}
+	}
+
+	// Decrypt the blob
+	plaintext, err := crypto.Decrypt(resp.RecoveryInfo, privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt recovery info: %w", err)
+	}
+
+	// Unmarshal and display
+	var info schema.RecoveryInfo
+	if err = json.Unmarshal(plaintext, &info); err != nil {
+		return fmt.Errorf("failed to unmarshal recovery info: %w", err)
+	}
+
+	fmt.Println("\nRecovery Information:")
+	global.Pretty(info)
+	return nil
+}
+
+// promptPassphrase reads a line from stdin (passphrase will be visible)
+func promptPassphrase(prompt string) (string, error) {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -67,7 +67,7 @@ func Register() *cobra.Command {
 	})
 
 	cmd.AddCommand(&cobra.Command{
-		Use:   "list",
+		Use:   "status",
 		Short: "list recovery info status for all agents",
 		Long:  "list all agents with their friendly name, agent ID, and recovery info status",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -233,8 +233,6 @@ func recoveryList(_ []string, _ *util.NVPairs) error {
 		return nil
 	}
 
-	fmt.Printf("\n%-30s %-36s %s\n", "Friendly Name", "Agent ID", "Recovery Info")
-	fmt.Printf("%s\n", strings.Repeat("-", 75))
 	for _, agent := range resp.Data.Agents {
 		recoveryStatus := "No"
 		if agent.RecoveryInfo != "" {

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -6,14 +6,13 @@
 package recovery
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/UnifyEM/UnifyEM/cli/communications"
 	"github.com/UnifyEM/UnifyEM/cli/display"
@@ -122,7 +121,7 @@ func recoveryKeygen(args []string, _ *util.NVPairs) error {
 
 func recoveryGet(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("agent ID is required\n")
+		return errors.New("agent ID is required")
 	}
 
 	agentID := args[0]
@@ -155,7 +154,7 @@ func recoveryGet(args []string, _ *util.NVPairs) error {
 	if err != nil {
 		// Only prompt for a passphrase if the key file exists but is encrypted;
 		// any other error (e.g. file not found) is returned immediately.
-		if !strings.Contains(err.Error(), "encrypted") {
+		if !errors.Is(err, crypto.ErrKeyEncrypted) {
 			return fmt.Errorf("failed to load private key: %w", err)
 		}
 		passphrase, pErr := promptPassphrase("Enter passphrase for private key: ")
@@ -187,7 +186,7 @@ func recoveryGet(args []string, _ *util.NVPairs) error {
 
 func recoveryCheck(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("agent ID is required\n")
+		return errors.New("agent ID is required")
 	}
 
 	agentID := args[0]
@@ -244,13 +243,13 @@ func recoveryList(_ []string, _ *util.NVPairs) error {
 	return nil
 }
 
-// promptPassphrase reads a line from stdin (passphrase will be visible)
+// promptPassphrase reads a passphrase from stdin with echo suppressed
 func promptPassphrase(prompt string) (string, error) {
 	fmt.Print(prompt)
-	reader := bufio.NewReader(os.Stdin)
-	line, err := reader.ReadString('\n')
+	b, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimRight(line, "\r\n"), nil
+	return string(b), nil
 }

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -135,7 +135,11 @@ func recoveryGet(args []string, _ *util.NVPairs) error {
 	// Try to load the private key without passphrase first
 	privateKey, err := crypto.LoadPrivateKeyPEM(keyPath, "")
 	if err != nil {
-		// Key may be encrypted — prompt for passphrase
+		// Only prompt for a passphrase if the key file exists but is encrypted;
+		// any other error (e.g. file not found) is returned immediately.
+		if !strings.Contains(err.Error(), "encrypted") {
+			return fmt.Errorf("failed to load private key: %w", err)
+		}
 		passphrase, pErr := promptPassphrase("Enter passphrase for private key: ")
 		if pErr != nil {
 			return fmt.Errorf("failed to read passphrase: %w", pErr)

--- a/cli/functions/recovery/recovery.go
+++ b/cli/functions/recovery/recovery.go
@@ -57,6 +57,24 @@ func Register() *cobra.Command {
 		},
 	})
 
+	cmd.AddCommand(&cobra.Command{
+		Use:   "check <agent_id>",
+		Short: "check if recovery info exists for agent",
+		Long:  "check whether recovery information has been received for the specified agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return recoveryCheck(args, util.NewNVPairs(args))
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "list recovery info status for all agents",
+		Long:  "list all agents with their friendly name, agent ID, and recovery info status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return recoveryList(args, util.NewNVPairs(args))
+		},
+	})
+
 	return cmd
 }
 
@@ -164,6 +182,67 @@ func recoveryGet(args []string, _ *util.NVPairs) error {
 
 	fmt.Println("\nRecovery Information:")
 	global.Pretty(info)
+	return nil
+}
+
+func recoveryCheck(args []string, _ *util.NVPairs) error {
+	if len(args) == 0 {
+		return errors.New("agent ID is required\n")
+	}
+
+	agentID := args[0]
+
+	c := communications.New(login.Login())
+	statusCode, data, err := c.Get(schema.EndpointAgent + "/" + agentID + "/recovery")
+	if err != nil {
+		return fmt.Errorf("failed to retrieve recovery info: %w", err)
+	}
+
+	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
+
+	var resp schema.APIRecoveryResponse
+	if err = json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if resp.RecoveryInfo != "" {
+		fmt.Printf("Recovery info available\n")
+	} else {
+		fmt.Printf("No recovery info available\n")
+	}
+
+	return nil
+}
+
+func recoveryList(_ []string, _ *util.NVPairs) error {
+	c := communications.New(login.Login())
+	statusCode, data, err := c.Get(schema.EndpointAgent)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve agent list: %w", err)
+	}
+
+	fmt.Printf("\nServer response: HTTP %d\n", statusCode)
+
+	var resp schema.APIAgentInfoResponse
+	if err = json.Unmarshal(data, &resp); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if len(resp.Data.Agents) == 0 {
+		fmt.Printf("No agents found\n")
+		return nil
+	}
+
+	fmt.Printf("\n%-30s %-36s %s\n", "Friendly Name", "Agent ID", "Recovery Info")
+	fmt.Printf("%s\n", strings.Repeat("-", 75))
+	for _, agent := range resp.Data.Agents {
+		recoveryStatus := "No"
+		if agent.RecoveryInfo != "" {
+			recoveryStatus = "Yes"
+		}
+		fmt.Printf("%-30s %-36s %s\n", agent.FriendlyName, agent.AgentID, recoveryStatus)
+	}
+
 	return nil
 }
 

--- a/cli/functions/request/request.go
+++ b/cli/functions/request/request.go
@@ -26,9 +26,9 @@ func Register() *cobra.Command {
 		Long:    "query, delete, and cancel agent requests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
-				return fmt.Errorf("A subcommand is required\n")
+				return fmt.Errorf("a subcommand is required")
 			}
-			return fmt.Errorf("Unknown subcommand: %s\n", args[0])
+			return fmt.Errorf("unknown subcommand: %s", args[0])
 		},
 	}
 
@@ -93,7 +93,7 @@ func requestList(args []string, _ *util.NVPairs) error {
 
 func requestGet(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("Request ID is required\n")
+		return errors.New("request ID is required")
 	}
 
 	c := communications.New(login.Login())
@@ -103,7 +103,7 @@ func requestGet(args []string, _ *util.NVPairs) error {
 
 func requestDelete(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("Request ID is required\n")
+		return errors.New("request ID is required")
 	}
 
 	c := communications.New(login.Login())
@@ -113,7 +113,7 @@ func requestDelete(args []string, _ *util.NVPairs) error {
 
 func requestCancel(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("Request ID is required\n")
+		return errors.New("request ID is required")
 	}
 
 	c := communications.New(login.Login())
@@ -123,7 +123,7 @@ func requestCancel(args []string, _ *util.NVPairs) error {
 
 func requestCancelAgent(args []string, _ *util.NVPairs) error {
 	if len(args) == 0 {
-		return errors.New("Agent ID is required\n")
+		return errors.New("agent ID is required")
 	}
 
 	c := communications.New(login.Login())

--- a/cli/functions/request/request.go
+++ b/cli/functions/request/request.go
@@ -23,7 +23,7 @@ func Register() *cobra.Command {
 		Use:     "request",
 		Aliases: []string{"requests"},
 		Short:   "request functions",
-		Long:    "query and delete agent requests",
+		Long:    "query, delete, and cancel agent requests",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("A subcommand is required\n")
@@ -33,9 +33,9 @@ func Register() *cobra.Command {
 	}
 
 	cmd.AddCommand(&cobra.Command{
-		Use:   "list",
+		Use:   "list [agent_id]",
 		Short: "list requests",
-		Long:  "request a list of requests",
+		Long:  "list all requests, or all requests for a specified agent",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return requestList(args, util.NewNVPairs(args))
 		},
@@ -59,12 +59,34 @@ func Register() *cobra.Command {
 		},
 	})
 
+	cmd.AddCommand(&cobra.Command{
+		Use:   "cancel <request_id>",
+		Short: "cancel request",
+		Long:  "cancel the specified request",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestCancel(args, util.NewNVPairs(args))
+		},
+	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "cancel-agent <agent_id>",
+		Short: "cancel agent requests",
+		Long:  "cancel all requests for the specified agent",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return requestCancelAgent(args, util.NewNVPairs(args))
+		},
+	})
+
 	return cmd
 }
 
-func requestList(_ []string, _ *util.NVPairs) error {
+func requestList(args []string, _ *util.NVPairs) error {
 	c := communications.New(login.Login())
-	display.ErrorWrapper(display.RequestList(c.Get(schema.EndpointRequest)))
+	if len(args) > 0 {
+		display.ErrorWrapper(display.RequestList(c.Get(schema.EndpointAgent + "/" + args[0] + "/requests")))
+	} else {
+		display.ErrorWrapper(display.RequestList(c.Get(schema.EndpointRequest)))
+	}
 	return nil
 }
 
@@ -85,5 +107,25 @@ func requestDelete(args []string, _ *util.NVPairs) error {
 
 	c := communications.New(login.Login())
 	display.ErrorWrapper(display.GenericResp(c.Delete(schema.EndpointRequest + "/" + args[0])))
+	return nil
+}
+
+func requestCancel(args []string, _ *util.NVPairs) error {
+	if len(args) == 0 {
+		return errors.New("Request ID is required\n")
+	}
+
+	c := communications.New(login.Login())
+	display.ErrorWrapper(display.GenericResp(c.Post(schema.EndpointRequest+"/"+args[0]+"/cancel", nil)))
+	return nil
+}
+
+func requestCancelAgent(args []string, _ *util.NVPairs) error {
+	if len(args) == 0 {
+		return errors.New("Agent ID is required\n")
+	}
+
+	c := communications.New(login.Login())
+	display.ErrorWrapper(display.GenericResp(c.Post(schema.EndpointAgent+"/"+args[0]+"/cancel-requests", nil)))
 	return nil
 }

--- a/cli/functions/request/request.go
+++ b/cli/functions/request/request.go
@@ -36,6 +36,7 @@ func Register() *cobra.Command {
 		Use:   "list [agent_id]",
 		Short: "list requests",
 		Long:  "list all requests, or all requests for a specified agent",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return requestList(args, util.NewNVPairs(args))
 		},
@@ -70,7 +71,7 @@ func Register() *cobra.Command {
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "cancel-agent <agent_id>",
-		Short: "cancel agent requests",
+		Short: "cancel all requests for agent",
 		Long:  "cancel all requests for the specified agent",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return requestCancelAgent(args, util.NewNVPairs(args))

--- a/cli/global/global.go
+++ b/cli/global/global.go
@@ -14,7 +14,7 @@ const (
 	Name            = "UEMCLI"
 	Description     = "UnifyEM CLI"
 	LongDescription = "UnifyEM command line interface"
-	Copyright       = "Copyright (c) 2024-2025 Tenebris Technologies Inc."
+	Copyright       = "Copyright (c) 2024-2026 Tenebris Technologies Inc."
 )
 
 var ServerURL string

--- a/cli/main.go
+++ b/cli/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/UnifyEM/UnifyEM/cli/functions/events"
 	"github.com/UnifyEM/UnifyEM/cli/functions/files"
 	"github.com/UnifyEM/UnifyEM/cli/functions/ping"
+	"github.com/UnifyEM/UnifyEM/cli/functions/recovery"
 	"github.com/UnifyEM/UnifyEM/cli/functions/regToken"
 	"github.com/UnifyEM/UnifyEM/cli/functions/report"
 	"github.com/UnifyEM/UnifyEM/cli/functions/request"
@@ -55,6 +56,7 @@ func main() {
 	rootCmd.AddCommand(events.Register())
 	rootCmd.AddCommand(files.Register())
 	rootCmd.AddCommand(ping.Register())
+	rootCmd.AddCommand(recovery.Register())
 	rootCmd.AddCommand(report.Register())
 	rootCmd.AddCommand(request.Register())
 	rootCmd.AddCommand(version.Register())

--- a/common/banner.go
+++ b/common/banner.go
@@ -9,7 +9,7 @@ import "fmt"
 
 func Banner(program, version string, build int) {
 	fmt.Printf("%s version %s (build %d)\n", program, version, build)
-	fmt.Printf("Copyright 2024-2025 Tenebris Technologies Inc.\n")
+	fmt.Printf("Copyright 2024-2026 Tenebris Technologies Inc.\n")
 	fmt.Printf("\nLicense:\n")
 	fmt.Printf("  This software is licenced under the Apache License, Version 2.0.\n")
 	fmt.Printf("  A copy of the license can be found in the LICENSE file.\n")

--- a/common/crypto/pem.go
+++ b/common/crypto/pem.go
@@ -12,12 +12,16 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"golang.org/x/crypto/scrypt"
 )
+
+// ErrKeyEncrypted is returned when a PEM key is encrypted but no passphrase was provided
+var ErrKeyEncrypted = errors.New("key is encrypted but no passphrase provided")
 
 const (
 	pemTypeEC          = "EC PRIVATE KEY"
@@ -122,7 +126,7 @@ func LoadPrivateKeyPEM(path string, passphrase string) (string, error) {
 
 	case pemTypeEncryptedEC:
 		if passphrase == "" {
-			return "", fmt.Errorf("key is encrypted but no passphrase provided")
+			return "", ErrKeyEncrypted
 		}
 		if len(block.Bytes) < saltLen {
 			return "", fmt.Errorf("invalid encrypted key data")

--- a/common/crypto/pem.go
+++ b/common/crypto/pem.go
@@ -1,0 +1,169 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	pemTypeEC          = "EC PRIVATE KEY"
+	pemTypeEncryptedEC = "ENCRYPTED EC PRIVATE KEY"
+	scryptN            = 32768
+	scryptR            = 8
+	scryptP            = 1
+	scryptKeyLen       = 32
+	saltLen            = 32
+)
+
+// GenerateSingleKeyPair generates a single P-384 keypair and returns the private and public keys
+// as base64-encoded strings (same encoding as the rest of the crypto package)
+func GenerateSingleKeyPair() (privateKey, publicKey string, err error) {
+	_, _, privateKey, publicKey, err = GenerateKeyPairs()
+	// GenerateKeyPairs returns sig and enc pairs; we reuse the enc pair for recovery
+	return privateKey, publicKey, err
+}
+
+// SavePrivateKeyPEM saves a base64-encoded EC private key to a PEM file.
+// If passphrase is non-empty the key is encrypted with scrypt + AES-GCM.
+func SavePrivateKeyPEM(privateKeyBase64 string, path string, passphrase string) error {
+	// Decode the base64 key
+	keyBytes, err := base64.StdEncoding.DecodeString(privateKeyBase64)
+	if err != nil {
+		return fmt.Errorf("failed to decode private key: %w", err)
+	}
+
+	var block *pem.Block
+
+	if passphrase == "" {
+		block = &pem.Block{
+			Type:  pemTypeEC,
+			Bytes: keyBytes,
+		}
+	} else {
+		// Generate random salt
+		salt := make([]byte, saltLen)
+		if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+			return fmt.Errorf("failed to generate salt: %w", err)
+		}
+
+		// Derive key from passphrase using scrypt
+		derivedKey, err := scrypt.Key([]byte(passphrase), salt, scryptN, scryptR, scryptP, scryptKeyLen)
+		if err != nil {
+			return fmt.Errorf("failed to derive key: %w", err)
+		}
+
+		// Encrypt with AES-GCM
+		aesCipher, err := aes.NewCipher(derivedKey)
+		if err != nil {
+			return fmt.Errorf("failed to create AES cipher: %w", err)
+		}
+		gcm, err := cipher.NewGCM(aesCipher)
+		if err != nil {
+			return fmt.Errorf("failed to create GCM: %w", err)
+		}
+		nonce := make([]byte, gcm.NonceSize())
+		if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+			return fmt.Errorf("failed to generate nonce: %w", err)
+		}
+		ciphertext := gcm.Seal(nonce, nonce, keyBytes, nil)
+
+		// Combine salt + ciphertext
+		payload := append(salt, ciphertext...)
+
+		block = &pem.Block{
+			Type:  pemTypeEncryptedEC,
+			Bytes: payload,
+		}
+	}
+
+	// Write PEM file
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close()
+
+	return pem.Encode(f, block)
+}
+
+// LoadPrivateKeyPEM loads a PEM-encoded EC private key from a file.
+// If the key is encrypted, passphrase must be provided.
+// Returns the private key as a base64-encoded string.
+func LoadPrivateKeyPEM(path string, passphrase string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read key file: %w", err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM block")
+	}
+
+	var keyBytes []byte
+
+	switch block.Type {
+	case pemTypeEC:
+		keyBytes = block.Bytes
+
+	case pemTypeEncryptedEC:
+		if passphrase == "" {
+			return "", fmt.Errorf("key is encrypted but no passphrase provided")
+		}
+		if len(block.Bytes) < saltLen {
+			return "", fmt.Errorf("invalid encrypted key data")
+		}
+
+		salt := block.Bytes[:saltLen]
+		ciphertext := block.Bytes[saltLen:]
+
+		derivedKey, err := scrypt.Key([]byte(passphrase), salt, scryptN, scryptR, scryptP, scryptKeyLen)
+		if err != nil {
+			return "", fmt.Errorf("failed to derive key: %w", err)
+		}
+
+		aesCipher, err := aes.NewCipher(derivedKey)
+		if err != nil {
+			return "", fmt.Errorf("failed to create AES cipher: %w", err)
+		}
+		gcm, err := cipher.NewGCM(aesCipher)
+		if err != nil {
+			return "", fmt.Errorf("failed to create GCM: %w", err)
+		}
+		if len(ciphertext) < gcm.NonceSize() {
+			return "", fmt.Errorf("ciphertext too short")
+		}
+		nonce := ciphertext[:gcm.NonceSize()]
+		ciphertext = ciphertext[gcm.NonceSize():]
+
+		keyBytes, err = gcm.Open(nil, nonce, ciphertext, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to decrypt key (wrong passphrase?): %w", err)
+		}
+
+	default:
+		return "", fmt.Errorf("unexpected PEM type: %s", block.Type)
+	}
+
+	// Validate it's a valid EC private key
+	_, err = x509.ParseECPrivateKey(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("invalid EC private key: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(keyBytes), nil
+}

--- a/common/crypto/validate.go
+++ b/common/crypto/validate.go
@@ -1,0 +1,33 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+)
+
+// ValidatePublicKey verifies that the provided string is a valid base64-encoded
+// PKIX EC public key, matching the format produced by GenerateKeyPairs.
+func ValidatePublicKey(key string) error {
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return fmt.Errorf("failed to base64-decode public key: %w", err)
+	}
+
+	pubKeyInterface, err := x509.ParsePKIXPublicKey(pubKeyBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	if _, ok := pubKeyInterface.(*ecdsa.PublicKey); !ok {
+		return fmt.Errorf("public key is not an EC public key")
+	}
+
+	return nil
+}

--- a/common/schema/agentConfig.go
+++ b/common/schema/agentConfig.go
@@ -28,6 +28,7 @@ const (
 	ConfigAgentPinCA            = "pin_ca"
 	ConfigAgentVerification     = "verification"
 	configAgentVerificationKey  = "verification_key"
+	ConfigAgentRecoveryInfo     = "recovery_info"
 )
 
 func SetAgentDefaults(c interfaces.Config) interfaces.Parameters {
@@ -47,5 +48,6 @@ func SetAgentDefaults(c interfaces.Config) interfaces.Parameters {
 	s.SetConstraint(ConfigAgentPinCA, 0, 0, false)
 	s.SetConstraint(ConfigAgentVerification, 0, 0, false)
 	s.SetConstraint(configAgentVerificationKey, 0, 0, "")
+	s.SetConstraint(ConfigAgentRecoveryInfo, 0, 0, false)
 	return s
 }

--- a/common/schema/agents.go
+++ b/common/schema/agents.go
@@ -23,6 +23,7 @@ type AgentMeta struct {
 	ClientPublicSig    string        `json:"client_public_sig,omitempty"`
 	ClientPublicEnc    string        `json:"client_public_enc,omitempty"`
 	ServiceCredentials string        `json:"service_credentials,omitempty"` // Encrypted "username:password" with agent's public key
+	RecoveryInfo       string        `json:"recovery_info,omitempty"`       // Encrypted recovery info blob
 }
 
 func NewAgentMeta(agentID string) AgentMeta {

--- a/common/schema/apiMeta.go
+++ b/common/schema/apiMeta.go
@@ -24,6 +24,7 @@ const (
 	EndpointEvents           = "/api/v1/events"
 	EndpointCreateDeployFile = "/api/v1/deployfile"
 	EndpointFiles            = "/files"
+	EndpointRecovery         = "/api/v1/recovery"
 	DeployInfoFile           = "deploy.json"
 )
 

--- a/common/schema/apiRequests.go
+++ b/common/schema/apiRequests.go
@@ -14,6 +14,7 @@ type AgentRegisterRequest struct {
 	Build           int    `json:"build"`
 	ClientPublicSig string `json:"client_public_sig,omitempty"`
 	ClientPublicEnc string `json:"client_public_enc,omitempty"`
+	FriendlyName    string `json:"friendly_name,omitempty"`
 }
 
 // LoginRequest is sent to the server by a user (administrator) to obtain a token

--- a/common/schema/apiRequests.go
+++ b/common/schema/apiRequests.go
@@ -59,6 +59,8 @@ type AgentResponse struct {
 	Success            bool   `json:"success"`
 	Data               any    `json:"data,omitempty"`
 	ServiceCredentials string `json:"service_credentials,omitempty"` // Double-encrypted "username:password" for server
+	PreShutdown        bool   `json:"-"`                             // trigger sync before OS action
+	ShutdownType       string `json:"-"`                             // "shutdown" or "reboot"
 }
 
 // NewAgentResponse creates a new AgentResponse and initialized the map to avoid errors

--- a/common/schema/apiRequests.go
+++ b/common/schema/apiRequests.go
@@ -36,10 +36,11 @@ type RefreshRequest struct {
 
 // AgentSyncRequest is sent by an agent to the server to synchronize data
 type AgentSyncRequest struct {
-	Version   string          `json:"version"`
-	Build     int             `json:"build"`
-	Messages  []AgentMessage  `json:"messages"`
-	Responses []AgentResponse `json:"responses"` // List of responses to previous requests
+	Version      string          `json:"version"`
+	Build        int             `json:"build"`
+	Messages     []AgentMessage  `json:"messages"`
+	Responses    []AgentResponse `json:"responses"`              // List of responses to previous requests
+	RecoveryInfo string          `json:"recovery_info,omitempty"` // Encrypted recovery info blob
 }
 
 // AgentMessage is a message from the agent to the server
@@ -79,6 +80,11 @@ func NewCmdRequest() CmdRequest {
 	return CmdRequest{
 		Parameters: make(map[string]string),
 	}
+}
+
+// RecoveryKeyRequest is used to upload the recovery public key to the server
+type RecoveryKeyRequest struct {
+	PublicKey string `json:"public_key"`
 }
 
 // ConfigRequest is used to change configuration parameters

--- a/common/schema/apiResponses.go
+++ b/common/schema/apiResponses.go
@@ -110,13 +110,14 @@ type APIConfigResponse struct {
 
 // APISyncResponse is sent to the agent by the server in response to an agent sync request
 type APISyncResponse struct {
-	Status             string            `json:"status"`
-	Code               int               `json:"code"`
-	Conf               map[string]string `json:"conf"`
-	Triggers           AgentTriggers     `json:"triggers"`
-	Details            string            `json:"details,omitempty"`
-	Requests           []AgentRequest    `json:"requests"`                      // Requests for the agent to process and respond to
-	ServiceCredentials string            `json:"service_credentials,omitempty"` // Encrypted "username:password" with agent's public key
+	Status              string            `json:"status"`
+	Code                int               `json:"code"`
+	Conf                map[string]string `json:"conf"`
+	Triggers            AgentTriggers     `json:"triggers"`
+	Details             string            `json:"details,omitempty"`
+	Requests            []AgentRequest    `json:"requests"`                        // Requests for the agent to process and respond to
+	ServiceCredentials  string            `json:"service_credentials,omitempty"`   // Encrypted "username:password" with agent's public key
+	RecoveryPublicKey   string            `json:"recovery_public_key,omitempty"`   // Recovery public key to distribute to agents
 }
 
 // AgentRequest contains a single command (request) from the server to the agent
@@ -163,6 +164,14 @@ type APIRegisterResponse struct {
 	RefreshToken    string `json:"refresh_token"`
 	ServerPublicSig string `json:"server_public_sig,omitempty"`
 	ServerPublicEnc string `json:"server_public_enc,omitempty"`
+}
+
+// APIRecoveryResponse is used to return an agent's encrypted recovery blob
+type APIRecoveryResponse struct {
+	Status       string `json:"status"`
+	Code         int    `json:"code"`
+	Details      string `json:"details,omitempty"`
+	RecoveryInfo string `json:"recovery_info,omitempty"`
 }
 
 // APICmdResponse is used by the API to respond to a command request

--- a/common/schema/recovery.go
+++ b/common/schema/recovery.go
@@ -14,4 +14,5 @@ type RecoveryInfo struct {
 	Hostname        string    `json:"hostname"`
 	ServiceAccount  string    `json:"service_account,omitempty"`
 	ServicePassword string    `json:"service_password,omitempty"`
+	BitLockerInfo   string    `json:"bitlocker_info,omitempty"`
 }

--- a/common/schema/recovery.go
+++ b/common/schema/recovery.go
@@ -1,0 +1,17 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package schema
+
+import "time"
+
+// RecoveryInfo contains recovery information collected by the agent
+type RecoveryInfo struct {
+	Timestamp       time.Time `json:"timestamp"`
+	OS              string    `json:"os"`
+	Hostname        string    `json:"hostname"`
+	ServiceAccount  string    `json:"service_account,omitempty"`
+	ServicePassword string    `json:"service_password,omitempty"`
+}

--- a/common/schema/requests.go
+++ b/common/schema/requests.go
@@ -8,11 +8,12 @@ package schema
 import "time"
 
 const (
-	RequestStatusNew      = "new"
-	RequestStatusPending  = "pending"
-	RequestStatusComplete = "complete"
-	RequestStatusFailed   = "failed"
-	RequestStatusInvalid  = "invalid"
+	RequestStatusNew       = "new"
+	RequestStatusPending   = "pending"
+	RequestStatusComplete  = "complete"
+	RequestStatusFailed    = "failed"
+	RequestStatusInvalid   = "invalid"
+	RequestStatusCancelled = "cancelled"
 )
 
 type AgentRequestRecord struct {

--- a/common/version.go
+++ b/common/version.go
@@ -6,6 +6,6 @@
 package common
 
 const (
-	Version = "0.0.57"
-	Build   = 105
+	Version = "0.0.58"
+	Build   = 106
 )

--- a/common/version.go
+++ b/common/version.go
@@ -6,6 +6,6 @@
 package common
 
 const (
-	Version = "0.0.54"
-	Build   = 100 
+	Version = "0.0.55"
+	Build   = 101
 )

--- a/common/version.go
+++ b/common/version.go
@@ -6,6 +6,6 @@
 package common
 
 const (
-	Version = "0.0.55"
-	Build   = 102
+	Version = "0.0.56"
+	Build   = 103
 )

--- a/common/version.go
+++ b/common/version.go
@@ -6,6 +6,6 @@
 package common
 
 const (
-	Version = "0.0.56"
-	Build   = 103
+	Version = "0.0.57"
+	Build   = 105
 )

--- a/common/version.go
+++ b/common/version.go
@@ -7,5 +7,5 @@ package common
 
 const (
 	Version = "0.0.55"
-	Build   = 101
+	Build   = 102
 )

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-openapi/jsonpointer v0.22.5 // indirect
+	github.com/go-openapi/jsonpointer v0.23.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect
 	github.com/go-openapi/spec v0.22.4 // indirect
 	github.com/go-openapi/swag/conv v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
-github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
-github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
+github.com/go-openapi/jsonpointer v0.23.0 h1:c25HFTJ6uWGmoe5BQI6p72p4o7KnlWYsy1MeFlAumsw=
+github.com/go-openapi/jsonpointer v0.23.0/go.mod h1:iWRmZTrGn7XwYhtPt/fvdSFj1OfNBngqRT2UG3BxSqY=
 github.com/go-openapi/jsonreference v0.21.5 h1:6uCGVXU/aNF13AQNggxfysJ+5ZcU4nEAe+pJyVWRdiE=
 github.com/go-openapi/jsonreference v0.21.5/go.mod h1:u25Bw85sX4E2jzFodh1FOKMTZLcfifd1Q+iKKOUxExw=
 github.com/go-openapi/spec v0.22.4 h1:4pxGjipMKu0FzFiu/DPwN3CTBRlVM2yLf/YTWorYfDQ=

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -237,6 +237,27 @@ func (a *API) startAPI() error {
 		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
 
 	s.AddRoute(userver.Route{
+		Name:     "request-cancel",
+		Methods:  []string{"POST"},
+		Pattern:  schema.EndpointRequest + "/{id}/cancel",
+		JHandler: a.cancelRequest,
+		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
+
+	s.AddRoute(userver.Route{
+		Name:     "agent-requests",
+		Methods:  []string{"GET"},
+		Pattern:  schema.EndpointAgent + "/{id}/requests",
+		JHandler: a.getAgentRequests,
+		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
+
+	s.AddRoute(userver.Route{
+		Name:     "agent-cancel-requests",
+		Methods:  []string{"POST"},
+		Pattern:  schema.EndpointAgent + "/{id}/cancel-requests",
+		JHandler: a.cancelAgentRequests,
+		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
+
+	s.AddRoute(userver.Route{
 		Name:     "regToken",
 		Methods:  []string{"GET"},
 		Pattern:  schema.EndpointRegToken,

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -258,6 +258,20 @@ func (a *API) startAPI() error {
 		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
 
 	s.AddRoute(userver.Route{
+		Name:     "recovery-key",
+		Methods:  []string{"POST"},
+		Pattern:  schema.EndpointRecovery + "/key",
+		JHandler: a.postRecoveryKey,
+		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
+
+	s.AddRoute(userver.Route{
+		Name:     "agent-recovery",
+		Methods:  []string{"GET"},
+		Pattern:  schema.EndpointAgent + "/{id}/recovery",
+		JHandler: a.getAgentRecovery,
+		AuthFunc: a.NewAuthFunc(a.AuthAdmins())})
+
+	s.AddRoute(userver.Route{
 		Name:     "regToken",
 		Methods:  []string{"GET"},
 		Pattern:  schema.EndpointRegToken,

--- a/server/api/recovery.go
+++ b/server/api/recovery.go
@@ -1,0 +1,127 @@
+/******************************************************************************
+ * Copyright (c) 2024-2026 Tenebris Technologies Inc.                         *
+ * Please see the LICENSE file for details                                    *
+ ******************************************************************************/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/UnifyEM/UnifyEM/common/fields"
+	"github.com/UnifyEM/UnifyEM/common/schema"
+	"github.com/UnifyEM/UnifyEM/common/userver"
+	"github.com/UnifyEM/UnifyEM/server/global"
+)
+
+// @Summary Upload recovery public key
+// @Description Upload the recovery public key to the server for distribution to agents
+// @Tags Recovery
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body schema.RecoveryKeyRequest true "Recovery public key"
+// @Success 200 {object} schema.APIGenericResponse
+// @Failure 400 {object} schema.API400
+// @Failure 401 {object} schema.API401
+// @Failure 500 {object} schema.API500
+// @Router /recovery/key [post]
+func (a *API) postRecoveryKey(req *http.Request) userver.JResponse {
+
+	remoteIP := userver.RemoteIP(req)
+	authDetails := GetAuthDetails(req)
+	logFields := fields.NewFields(
+		fields.NewField("src_ip", remoteIP),
+		fields.NewField("id", authDetails.ID),
+		fields.NewField("role", authDetails.Role))
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		a.logger.Error(2910, fmt.Sprintf("failed reading body: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "error reading body", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	var keyReq schema.RecoveryKeyRequest
+	err = json.Unmarshal(body, &keyReq)
+	if err != nil {
+		a.logger.Error(2911, fmt.Sprintf("deserialization error: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "error unmarshalling JSON", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	if keyReq.PublicKey == "" {
+		a.logger.Error(2912, "recovery public key is empty", logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "public_key is required", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	a.conf.SC.Set(global.ConfigRecoveryPublicKey, keyReq.PublicKey)
+	if err = a.conf.Checkpoint(); err != nil {
+		a.logger.Error(2913, fmt.Sprintf("failed to save recovery key: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusInternalServerError,
+			JSONData: schema.API500{Details: "failed to save recovery key", Status: schema.APIStatusError, Code: http.StatusInternalServerError}}
+	}
+
+	a.logger.Info(2914, "recovery public key updated", logFields)
+	return userver.JResponse{
+		HTTPCode: http.StatusOK,
+		JSONData: schema.APIGenericResponse{
+			Status:  schema.APIStatusOK,
+			Code:    http.StatusOK,
+			Details: "recovery public key updated"}}
+}
+
+// @Summary Get agent recovery info
+// @Description Retrieve the encrypted recovery info blob for an agent
+// @Tags Recovery
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Agent ID"
+// @Success 200 {object} schema.APIRecoveryResponse
+// @Failure 400 {object} schema.API400
+// @Failure 401 {object} schema.API401
+// @Failure 404 {object} schema.API404
+// @Router /agent/{id}/recovery [get]
+func (a *API) getAgentRecovery(req *http.Request) userver.JResponse {
+
+	remoteIP := userver.RemoteIP(req)
+	authDetails := GetAuthDetails(req)
+	logFields := fields.NewFields(
+		fields.NewField("src_ip", remoteIP),
+		fields.NewField("id", authDetails.ID),
+		fields.NewField("role", authDetails.Role))
+
+	agentID := userver.GetParam(req, "id")
+	if agentID == "" {
+		a.logger.Error(2915, "no agent ID specified", logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "agent ID required", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	logFields.Append(fields.NewField("agentID", agentID))
+
+	info := a.data.GetAgentRecoveryInfo(agentID)
+	if info == "" {
+		a.logger.Info(2916, "no recovery info available for agent", logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusNotFound,
+			JSONData: schema.API404{Details: "no recovery info available", Status: schema.APIStatusError, Code: http.StatusNotFound}}
+	}
+
+	a.logger.Info(2917, "recovery info retrieved", logFields)
+	return userver.JResponse{
+		HTTPCode: http.StatusOK,
+		JSONData: schema.APIRecoveryResponse{
+			Status:       schema.APIStatusOK,
+			Code:         http.StatusOK,
+			RecoveryInfo: info}}
+}

--- a/server/api/recovery.go
+++ b/server/api/recovery.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/UnifyEM/UnifyEM/common/crypto"
 	"github.com/UnifyEM/UnifyEM/common/fields"
 	"github.com/UnifyEM/UnifyEM/common/schema"
 	"github.com/UnifyEM/UnifyEM/common/userver"
@@ -60,6 +61,13 @@ func (a *API) postRecoveryKey(req *http.Request) userver.JResponse {
 		return userver.JResponse{
 			HTTPCode: http.StatusBadRequest,
 			JSONData: schema.API400{Details: "public_key is required", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	if err = crypto.ValidatePublicKey(keyReq.PublicKey); err != nil {
+		a.logger.Error(2918, fmt.Sprintf("invalid recovery public key: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "invalid public key format", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
 	}
 
 	a.conf.SC.Set(global.ConfigRecoveryPublicKey, keyReq.PublicKey)
@@ -113,8 +121,10 @@ func (a *API) getAgentRecovery(req *http.Request) userver.JResponse {
 	if info == "" {
 		a.logger.Info(2916, "no recovery info available for agent", logFields)
 		return userver.JResponse{
-			HTTPCode: http.StatusNotFound,
-			JSONData: schema.API404{Details: "no recovery info available", Status: schema.APIStatusError, Code: http.StatusNotFound}}
+			HTTPCode: http.StatusOK,
+			JSONData: schema.APIRecoveryResponse{
+				Status: schema.APIStatusOK,
+				Code:   http.StatusOK}}
 	}
 
 	a.logger.Info(2917, "recovery info retrieved", logFields)

--- a/server/api/request.go
+++ b/server/api/request.go
@@ -127,3 +127,161 @@ func (a *API) deleteRequest(req *http.Request) userver.JResponse {
 			Code:    http.StatusOK,
 			Details: "request deleted"}}
 }
+
+// @Summary Cancel request
+// @Description Cancels a pending request by ID
+// @Tags Agent management
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Request ID"
+// @Success 200 {object} schema.APIGenericResponse
+// @Failure 400 {object} schema.API400
+// @Failure 401 {object} schema.API401
+// @Failure 404 {object} schema.API404
+// @Router /request/{id}/cancel [post]
+func (a *API) cancelRequest(req *http.Request) userver.JResponse {
+
+	remoteIP := userver.RemoteIP(req)
+	authDetails := GetAuthDetails(req)
+	logFields := fields.NewFields(
+		fields.NewField("src_ip", remoteIP),
+		fields.NewField("id", authDetails.ID),
+		fields.NewField("role", authDetails.Role))
+
+	// Extract the request ID from the URL
+	requestID := userver.GetParam(req, "id")
+	if requestID == "" {
+		a.logger.Error(2847, "no request specified", logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "request ID required", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	// Add request ID to log fields
+	logFields.Append(fields.NewField("requestID", requestID))
+
+	// Cancel the request in the database
+	err := a.data.CancelAgentRequest(requestID)
+	if err != nil {
+		a.logger.Info(2848, fmt.Sprintf("error cancelling agent request: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusNotFound,
+			JSONData: schema.API404{Details: "request not found", Status: schema.APIStatusError, Code: http.StatusNotFound}}
+	}
+
+	a.logger.Info(2849, "agent request cancelled", logFields)
+	return userver.JResponse{
+		HTTPCode: http.StatusOK,
+		JSONData: schema.APIGenericResponse{
+			Status:  schema.APIStatusOK,
+			Code:    http.StatusOK,
+			Details: "request cancelled"}}
+}
+
+// @Summary Retrieve all requests for an agent
+// @Description Returns all request records for a given agent ID
+// @Tags Agent management
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Agent ID"
+// @Success 200 {object} schema.APIRequestStatusResponse
+// @Failure 400 {object} schema.API400
+// @Failure 401 {object} schema.API401
+// @Failure 404 {object} schema.API404
+// @Failure 500 {object} schema.API500
+// @Router /agent/{id}/requests [get]
+func (a *API) getAgentRequests(req *http.Request) userver.JResponse {
+
+	remoteIP := userver.RemoteIP(req)
+	authDetails := GetAuthDetails(req)
+	logFields := fields.NewFields(
+		fields.NewField("src_ip", remoteIP),
+		fields.NewField("id", authDetails.ID),
+		fields.NewField("role", authDetails.Role))
+
+	// Extract the agent ID from the URL
+	agentID := userver.GetParam(req, "id")
+	if agentID == "" {
+		a.logger.Error(2853, "no agent ID specified", logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "agent ID required", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	// Add agent ID to log fields
+	logFields.Append(fields.NewField("agentID", agentID))
+
+	// Get all request records for the agent
+	requests, err := a.data.GetAgentRequestRecords(agentID)
+	if err != nil {
+		a.logger.Error(2854, fmt.Sprintf("error retrieving agent request records: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusInternalServerError,
+			JSONData: schema.API500{Details: "error retrieving agent requests", Status: schema.APIStatusError, Code: http.StatusInternalServerError}}
+	}
+
+	// Mask sensitive parameters before returning via API
+	for i := range requests.Requests {
+		if _, exists := requests.Requests[i].Parameters["password"]; exists {
+			requests.Requests[i].Parameters["password"] = "********"
+		}
+	}
+
+	a.logger.Info(2857, "agent requests retrieved", logFields)
+	return userver.JResponse{
+		HTTPCode: http.StatusOK,
+		JSONData: schema.APIRequestStatusResponse{
+			Status: schema.APIStatusOK,
+			Code:   http.StatusOK,
+			Data:   requests}}
+}
+
+// @Summary Cancel all requests for an agent
+// @Description Cancels all pending requests for the specified agent
+// @Tags Agent management
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Agent ID"
+// @Success 200 {object} schema.APIGenericResponse
+// @Failure 400 {object} schema.API400
+// @Failure 401 {object} schema.API401
+// @Failure 404 {object} schema.API404
+// @Router /agent/{id}/cancel-requests [post]
+func (a *API) cancelAgentRequests(req *http.Request) userver.JResponse {
+
+	remoteIP := userver.RemoteIP(req)
+	authDetails := GetAuthDetails(req)
+	logFields := fields.NewFields(
+		fields.NewField("src_ip", remoteIP),
+		fields.NewField("id", authDetails.ID),
+		fields.NewField("role", authDetails.Role))
+
+	// Extract the agent ID from the URL
+	agentID := userver.GetParam(req, "id")
+	if agentID == "" {
+		a.logger.Error(2867, "no agent ID specified", logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusBadRequest,
+			JSONData: schema.API400{Details: "agent ID required", Status: schema.APIStatusError, Code: http.StatusBadRequest}}
+	}
+
+	// Add agent ID to log fields
+	logFields.Append(fields.NewField("agentID", agentID))
+
+	// Cancel all requests for the agent in the database
+	err := a.data.CancelAgentRequests(agentID)
+	if err != nil {
+		a.logger.Info(2868, fmt.Sprintf("error cancelling agent requests: %s", err.Error()), logFields)
+		return userver.JResponse{
+			HTTPCode: http.StatusNotFound,
+			JSONData: schema.API404{Details: "agent not found", Status: schema.APIStatusError, Code: http.StatusNotFound}}
+	}
+
+	a.logger.Info(2869, "agent requests cancelled", logFields)
+	return userver.JResponse{
+		HTTPCode: http.StatusOK,
+		JSONData: schema.APIGenericResponse{
+			Status:  schema.APIStatusOK,
+			Code:    http.StatusOK,
+			Details: "agent requests cancelled"}}
+}

--- a/server/api/request.go
+++ b/server/api/request.go
@@ -163,7 +163,7 @@ func (a *API) cancelRequest(req *http.Request) userver.JResponse {
 	// Cancel the request in the database
 	err := a.data.CancelAgentRequest(requestID)
 	if err != nil {
-		a.logger.Info(2848, fmt.Sprintf("error cancelling agent request: %s", err.Error()), logFields)
+		a.logger.Error(2848, fmt.Sprintf("error cancelling agent request: %s", err.Error()), logFields)
 		return userver.JResponse{
 			HTTPCode: http.StatusNotFound,
 			JSONData: schema.API404{Details: "request not found", Status: schema.APIStatusError, Code: http.StatusNotFound}}
@@ -271,7 +271,7 @@ func (a *API) cancelAgentRequests(req *http.Request) userver.JResponse {
 	// Cancel all requests for the agent in the database
 	err := a.data.CancelAgentRequests(agentID)
 	if err != nil {
-		a.logger.Info(2868, fmt.Sprintf("error cancelling agent requests: %s", err.Error()), logFields)
+		a.logger.Error(2868, fmt.Sprintf("error cancelling agent requests: %s", err.Error()), logFields)
 		return userver.JResponse{
 			HTTPCode: http.StatusNotFound,
 			JSONData: schema.API404{Details: "agent not found", Status: schema.APIStatusError, Code: http.StatusNotFound}}

--- a/server/api/sync.go
+++ b/server/api/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/UnifyEM/UnifyEM/common/schema"
 	"github.com/UnifyEM/UnifyEM/common/userver"
 	"github.com/UnifyEM/UnifyEM/server/data"
+	"github.com/UnifyEM/UnifyEM/server/global"
 	"github.com/UnifyEM/UnifyEM/server/queue"
 )
 
@@ -111,10 +112,14 @@ func (a *API) postSync(req *http.Request) userver.JResponse {
 			RequestCount:  len(requests),
 			ResponseCount: len(syncRequest.Responses),
 			Responses:     syncRequest.Responses,
+			RecoveryInfo:  syncRequest.RecoveryInfo,
 		})
 
 	// Get service credentials for this agent (encrypted with agent's public key)
 	serviceCredentials := a.data.GetServiceCredentials(authDetails.ID)
+
+	// Get the recovery public key from server config
+	recoveryPublicKey := a.conf.SC.Get(global.ConfigRecoveryPublicKey).String()
 
 	// Return the response
 	return userver.JResponse{
@@ -126,5 +131,6 @@ func (a *API) postSync(req *http.Request) userver.JResponse {
 			Triggers:           triggers,
 			Details:            "ok",
 			Requests:           requests,
-			ServiceCredentials: serviceCredentials}}
+			ServiceCredentials: serviceCredentials,
+			RecoveryPublicKey:  recoveryPublicKey}}
 }

--- a/server/data/agents.go
+++ b/server/data/agents.go
@@ -6,6 +6,8 @@
 package data
 
 import (
+	"fmt"
+
 	"github.com/UnifyEM/UnifyEM/common/schema"
 )
 
@@ -40,6 +42,25 @@ func (d *Data) GetServiceCredentials(agentID string) string {
 		return ""
 	}
 	return meta.ServiceCredentials
+}
+
+// SetAgentRecoveryInfo stores the encrypted recovery info blob for an agent
+func (d *Data) SetAgentRecoveryInfo(agentID string, info string) error {
+	meta, err := d.database.GetAgentMeta(agentID)
+	if err != nil {
+		return fmt.Errorf("failed to get agent metadata: %w", err)
+	}
+	meta.RecoveryInfo = info
+	return d.database.SetAgentMeta(meta)
+}
+
+// GetAgentRecoveryInfo returns the encrypted recovery info blob for an agent
+func (d *Data) GetAgentRecoveryInfo(agentID string) string {
+	meta, err := d.database.GetAgentMeta(agentID)
+	if err != nil {
+		return ""
+	}
+	return meta.RecoveryInfo
 }
 
 // AgentDelete removes an agent from the database including any requests

--- a/server/data/register.go
+++ b/server/data/register.go
@@ -82,6 +82,9 @@ func (d *Data) Register(regRequest schema.AgentRegisterRequest, remoteIP string)
 	meta.Build = regRequest.Build
 	meta.ClientPublicSig = regRequest.ClientPublicSig
 	meta.ClientPublicEnc = regRequest.ClientPublicEnc
+	if regRequest.FriendlyName != "" {
+		meta.FriendlyName = regRequest.FriendlyName
+	}
 
 	// Log key receipt during registration
 	if regRequest.ClientPublicSig != "" {

--- a/server/data/requests.go
+++ b/server/data/requests.go
@@ -49,9 +49,24 @@ func (d *Data) GetRequestRecords() (schema.AgentRequestRecordList, error) {
 	return d.database.GetAllRequestRecords()
 }
 
+// GetAgentRequestRecords returns all request records for a given agent
+func (d *Data) GetAgentRequestRecords(agentID string) (schema.AgentRequestRecordList, error) {
+	return d.database.GetAgentRequestRecords(agentID)
+}
+
 // DeleteAgentRequest removes a request from the database
 func (d *Data) DeleteAgentRequest(requestKey string) error {
 	return d.database.DeleteAgentRequest(requestKey)
+}
+
+// CancelAgentRequest cancels a pending request by ID
+func (d *Data) CancelAgentRequest(requestKey string) error {
+	return d.database.CancelAgentRequest(requestKey)
+}
+
+// CancelAgentRequests cancels all pending requests for the specified agent
+func (d *Data) CancelAgentRequests(agentID string) error {
+	return d.database.CancelAgentRequests(agentID)
 }
 
 // GetAgentRequests returns a list of requests for an agent

--- a/server/data/sync.go
+++ b/server/data/sync.go
@@ -25,6 +25,7 @@ type SyncData struct {
 	RequestCount  int
 	ResponseCount int
 	Responses     []schema.AgentResponse
+	RecoveryInfo  string
 }
 
 // AgentSync updates metadata about the agent, sends responses for processing, and returns any triggers
@@ -73,6 +74,24 @@ func (d *Data) AgentSync(data SyncData) schema.AgentTriggers {
 					fields.NewField("requestID", response.RequestID)))
 		}
 	}
+
+	// Store recovery info if provided
+	if data.RecoveryInfo != "" {
+		meta, err := d.database.GetAgentMeta(data.AgentID)
+		if err == nil {
+			meta.RecoveryInfo = data.RecoveryInfo
+			if setErr := d.database.SetAgentMeta(meta); setErr != nil {
+				d.logger.Error(2711, "failed to store recovery info",
+					fields.NewFields(
+						fields.NewField("error", setErr.Error()),
+						fields.NewField("id", data.AgentID)))
+			} else {
+				d.logger.Info(2712, "recovery info stored",
+					fields.NewFields(fields.NewField("id", data.AgentID)))
+			}
+		}
+	}
+
 	return triggers
 }
 

--- a/server/db/agentRequest.go
+++ b/server/db/agentRequest.go
@@ -118,7 +118,7 @@ func (d *DB) CancelAgentRequest(requestKey string) error {
 	return nil
 }
 
-// CancelAgentRequests deletes all requests for the specified agent
+// CancelAgentRequests sets status to cancelled for all pending requests for the specified agent
 func (d *DB) CancelAgentRequests(agentID string) error {
 	//prefix := validateKey(agentID) + ":"
 

--- a/server/db/agentRequest.go
+++ b/server/db/agentRequest.go
@@ -76,12 +76,9 @@ func (d *DB) DeleteAgentRequest(requestKey string) error {
 
 // DeleteAgentRequests deletes all requests for the specified agent
 func (d *DB) DeleteAgentRequests(agentID string) error {
-	//prefix := validateKey(agentID) + ":"
-
 	// Iterate over all requests and delete those that match the agentID
+	// TODO: optimize with prefix scan when request keys include agentID prefix
 	err := d.ForEach(BucketAgentRequests, func(key, value []byte) error {
-		//if len(key) > len(prefix) {
-		//	if string(key[:len(prefix)]) == prefix {
 		var request schema.AgentRequestRecord
 		err := d.deserialize(value, &request)
 		if err != nil {
@@ -120,9 +117,8 @@ func (d *DB) CancelAgentRequest(requestKey string) error {
 
 // CancelAgentRequests sets status to cancelled for all pending requests for the specified agent
 func (d *DB) CancelAgentRequests(agentID string) error {
-	//prefix := validateKey(agentID) + ":"
-
-	// Iterate over all requests and delete those that match the agentID
+	// Iterate over all requests and cancel those that match the agentID
+	// TODO: optimize with prefix scan when request keys include agentID prefix
 	err := d.ForEach(BucketAgentRequests, func(key, value []byte) error {
 		var request schema.AgentRequestRecord
 		err := d.deserialize(value, &request)

--- a/server/db/agentRequest.go
+++ b/server/db/agentRequest.go
@@ -35,7 +35,6 @@ func (d *DB) SetAgentRequest(request schema.AgentRequestRecord) error {
 	if err != nil {
 		return fmt.Errorf("failed to store agent agent: %w", err)
 	}
-
 	return nil
 }
 
@@ -97,6 +96,46 @@ func (d *DB) DeleteAgentRequests(agentID string) error {
 
 		return nil
 
+	})
+	return err
+}
+
+// CancelAgentRequest cancels an agent request
+func (d *DB) CancelAgentRequest(requestKey string) error {
+	var err error
+
+	result := schema.NewDBAgentRequest()
+	err = d.GetData(BucketAgentRequests, requestKey, &result)
+	if err != nil {
+		return fmt.Errorf("failed to get agent request: %w", err)
+	}
+
+	if result.Status == schema.RequestStatusNew || result.Status == schema.RequestStatusPending {
+		result.Status = schema.RequestStatusCancelled
+		return d.SetAgentRequest(result)
+
+	}
+	return nil
+}
+
+// CancelAgentRequests deletes all requests for the specified agent
+func (d *DB) CancelAgentRequests(agentID string) error {
+	//prefix := validateKey(agentID) + ":"
+
+	// Iterate over all requests and delete those that match the agentID
+	err := d.ForEach(BucketAgentRequests, func(key, value []byte) error {
+		var request schema.AgentRequestRecord
+		err := d.deserialize(value, &request)
+		if err != nil {
+			return fmt.Errorf("failed to deserialize agent request: %w", err)
+		}
+		if request.AgentID == agentID {
+			err = d.CancelAgentRequest(string(key))
+			if err != nil {
+				return fmt.Errorf("failed to cancel agent request: %w", err)
+			}
+		}
+		return nil
 	})
 	return err
 }

--- a/server/db/requestList.go
+++ b/server/db/requestList.go
@@ -15,6 +15,7 @@ import (
 func (d *DB) GetAgentRequestRecords(agentID string) (schema.AgentRequestRecordList, error) {
 	var result schema.AgentRequestRecordList
 
+	// TODO: optimize with prefix scan when request keys include agentID prefix
 	err := d.ForEach(BucketAgentRequests, func(key, value []byte) error {
 		var request schema.AgentRequestRecord
 		err := d.deserialize(value, &request)
@@ -39,6 +40,7 @@ func (d *DB) GetAllRequestRecords() (schema.AgentRequestRecordList, error) {
 	var allRequests schema.AgentRequestRecordList
 
 	// Iterate over all keys in the bucket
+	// TODO: optimize with prefix scan when request keys include agentID prefix
 	err := d.ForEach(BucketAgentRequests, func(key, value []byte) error {
 		var request schema.AgentRequestRecord
 		err := d.deserialize(value, &request)

--- a/server/db/requestList.go
+++ b/server/db/requestList.go
@@ -11,6 +11,29 @@ import (
 	"github.com/UnifyEM/UnifyEM/common/schema"
 )
 
+// GetAgentRequestRecords retrieves all request records for a given agent
+func (d *DB) GetAgentRequestRecords(agentID string) (schema.AgentRequestRecordList, error) {
+	var result schema.AgentRequestRecordList
+
+	err := d.ForEach(BucketAgentRequests, func(key, value []byte) error {
+		var request schema.AgentRequestRecord
+		err := d.deserialize(value, &request)
+		if err != nil {
+			return fmt.Errorf("failed to deserialize request record: %w", err)
+		}
+		if request.AgentID == agentID {
+			result.Requests = append(result.Requests, request)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return schema.AgentRequestRecordList{}, fmt.Errorf("failed to retrieve agent request records: %w", err)
+	}
+
+	return result, nil
+}
+
 // GetAllRequestRecords retrieves all agent metadata from the AgentMeta bucket
 func (d *DB) GetAllRequestRecords() (schema.AgentRequestRecordList, error) {
 	var allRequests schema.AgentRequestRecordList

--- a/server/global/defaults.go
+++ b/server/global/defaults.go
@@ -35,6 +35,7 @@ const (
 	ConfigAgentRetention        = "agent_retention_days"
 	ConfigEventRetention        = "event_retention_days"
 	ConfigRequestRetention      = "request_retention_days"
+	ConfigRecoveryPublicKey     = "recovery_public_key"
 
 	ConfigPrivate                = "server_private"
 	ConfigRegToken               = "reg_token"
@@ -73,6 +74,7 @@ func setDefaults(c interfaces.Config) (interfaces.Parameters, interfaces.Paramet
 	sc.SetConstraint(ConfigAgentRetention, 1, 0, 365)                  // days
 	sc.SetConstraint(ConfigEventRetention, 1, 0, 365)                  // days
 	sc.SetConstraint(ConfigRequestRetention, 1, 0, 365)                // days
+	sc.SetConstraint(ConfigRecoveryPublicKey, 0, 0, "")
 
 	// Protected configuration items
 	sp := c.NewSet(ConfigPrivate)


### PR DESCRIPTION
## Summary

- **Recovery key system**: Administrators can generate an EC (P-384) keypair, upload the public key to the server, and retrieve encrypted recovery information per agent. Recovery info includes OS details, hostname, service account credentials, and BitLocker recovery data (Windows). CLI commands: `recovery keygen`, `recovery get`, `recovery check`, `recovery status`
- **Windows service account**: Agent creates a dedicated local service account with a random password on install; password rotates on request. BitLocker key protectors are updated automatically when the password rotates to maintain recovery access
- **Linux service account**: Agent creates a dedicated local service account on Linux during installation
- **BitLocker recovery info**: Agent captures `manage-bde` output on Windows and includes it in the encrypted recovery blob sent to the server
- **Recovery info reliability**: A persistent `recovery_info_pending` flag ensures recovery info (including service credentials) is re-sent after agent restart, preventing a race where credentials arrive after the initial recovery blob was already sent
- **Self-signed certificate support (CLI)**: `uem-cli` accepts self-signed server certificates using SHA-256 fingerprint pinning, stored in a local cert store
- **CLI `recovery status`**: Lists all agents with friendly name, agent ID, and whether recovery info has been received
- **CLI `agent status`**: Lists all agents with friendly name, agent ID, days since last check-in, and version/build number
- **CLI request cancellation**: Added `request cancel <request_id>` and `request list <agent_id>` subcommands
- **Friendly name at install time**: Administrators can pass an optional friendly name during agent installation (`uem-agent install <token> [name]`); it is sent during registration and stored as the agent's display name
- **Pre-shutdown sync**: Agent completes a final sync to the server before shutdown or reboot commands take effect
- **Windows install robustness**: Install now handles the case where a stopped service already exists in SCM (starts it rather than failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)